### PR TITLE
Support Autocrypt Setup Message #100 OT-206

### DIFF
--- a/lib/src/chat/chat.dart
+++ b/lib/src/chat/chat.dart
@@ -246,7 +246,8 @@ class _ChatState extends State<Chat> with ChatComposer {
           child: Row(
             children: <Widget>[
               Avatar(
-                initials: getInitials(name, subTitle),
+                textPrimary: name,
+                textSecondary: subTitle,
                 color: color,
               ),
               Padding(padding: EdgeInsets.only(left: appBarAvatarTextPadding)),
@@ -461,16 +462,6 @@ class _ChatState extends State<Chat> with ChatComposer {
   _onCameraStateChange(bool pickImage) async {
     hideOverlay();
     _chatComposerBloc.dispatch(StartImageOrVideoRecording(pickImage: pickImage));
-  }
-
-  String getInitials(String name, String subTitle) {
-    if (name != null && name.isNotEmpty) {
-      return name.substring(0, 1);
-    }
-    if (subTitle != null && subTitle.isNotEmpty) {
-      return subTitle.substring(0, 1);
-    }
-    return "";
   }
 
   void _showAttachmentChooser() {

--- a/lib/src/chat/chat_create_group_settings.dart
+++ b/lib/src/chat/chat_create_group_settings.dart
@@ -59,6 +59,7 @@ import 'package:ox_coi/src/navigation/navigatable.dart';
 import 'package:ox_coi/src/navigation/navigation.dart';
 import 'package:ox_coi/src/utils/colors.dart';
 import 'package:ox_coi/src/utils/dimensions.dart';
+import 'package:ox_coi/src/widgets/validatable_text_form_field.dart';
 import 'package:rxdart/rxdart.dart';
 
 class ChatCreateGroupSettings extends StatefulWidget {
@@ -72,7 +73,12 @@ class ChatCreateGroupSettings extends StatefulWidget {
 
 class _ChatCreateGroupSettingsState extends State<ChatCreateGroupSettings> {
   ContactListBloc _contactListBloc = ContactListBloc();
-  TextEditingController _controller = TextEditingController();
+  ValidatableTextFormField _groupNameField = ValidatableTextFormField(
+    (context) => AppLocalizations.of(context).createGroupTextFieldLabel,
+    hintText: (context) => AppLocalizations.of(context).createGroupTextFieldHint,
+    needValidation: true,
+    validationHint: (context) => AppLocalizations.of(context).validatableTextFormFieldHintEmptyString,
+  );
   GlobalKey<FormState> _formKey = GlobalKey();
   Repository<Core.Chat> chatRepository;
   Navigation navigation = Navigation();
@@ -137,21 +143,12 @@ class _ChatCreateGroupSettingsState extends State<ChatCreateGroupSettings> {
           ),
         ),
         Padding(
-            padding: EdgeInsets.only(left: formHorizontalPadding, right: formHorizontalPadding),
-            child: Form(
-              key: _formKey,
-              child: TextFormField(
-                decoration: InputDecoration(
-                    labelText: AppLocalizations.of(context).createGroupTextFieldLabel,
-                    hintText: AppLocalizations.of(context).createGroupTextFieldHint),
-                validator: (value) {
-                  if (value.isEmpty) {
-                    return AppLocalizations.of(context).validatableTextFormFieldHintEmptyString;
-                  }
-                },
-                controller: _controller,
-              ),
-            )),
+          padding: EdgeInsets.only(left: formHorizontalPadding, right: formHorizontalPadding),
+          child: Form(
+            key: _formKey,
+            child: _groupNameField,
+          ),
+        ),
         Padding(
           padding: EdgeInsets.only(
             left: formHorizontalPadding,
@@ -180,7 +177,7 @@ class _ChatCreateGroupSettingsState extends State<ChatCreateGroupSettings> {
       ChatChangeBloc chatChangeBloc = ChatChangeBloc();
       final changeChatStatesObservable = new Observable<ChatChangeState>(chatChangeBloc.state);
       changeChatStatesObservable.listen((state) => _handleChatChangeStateChange(state));
-      chatChangeBloc.dispatch(CreateChat(verified: false, name: _controller.text, contacts: widget._selectedContacts));
+      chatChangeBloc.dispatch(CreateChat(verified: false, name: _groupNameField.controller.text, contacts: widget._selectedContacts));
     }
   }
 

--- a/lib/src/contact/contact_change.dart
+++ b/lib/src/contact/contact_change.dart
@@ -107,6 +107,8 @@ class _ContactChangeState extends State<ContactChange> {
         (context) => AppLocalizations.of(context).emailAddress,
         textFormType: TextFormType.email,
         inputType: TextInputType.emailAddress,
+        needValidation: true,
+        validationHint: (context) => AppLocalizations.of(context).validatableTextFormFieldHintInvalidEmail,
       );
     } else {
       _nameField.controller.text = widget.name != null ? widget.name : "";
@@ -250,28 +252,16 @@ class _ContactChangeState extends State<ContactChange> {
   }
 
   onDelete(BuildContext context) {
-    showNavigatableDialog(
+    showConfirmationDialog(
       context: context,
+      title: AppLocalizations.of(context).contactChangeDeleteTitle,
+      content: (AppLocalizations.of(context).contactChangeDeleteDialogContent(getEmail(), getName())),
+      positiveButton: AppLocalizations.of(context).delete,
+      positiveAction: () {
+        _contactChangeBloc.dispatch(DeleteContact(widget.id));
+        navigation.pop(context);
+      },
       navigatable: Navigatable(Type.contactDeleteDialog),
-      dialog: AlertDialog(
-        title: Text(AppLocalizations.of(context).contactChangeDeleteTitle),
-        content: new Text(AppLocalizations.of(context).contactChangeDeleteDialogContent(getEmail(), getName())),
-        actions: <Widget>[
-          new FlatButton(
-            child: new Text(AppLocalizations.of(context).no),
-            onPressed: () {
-              navigation.pop(context);
-            },
-          ),
-          new FlatButton(
-            child: new Text(AppLocalizations.of(context).delete),
-            onPressed: () {
-              _contactChangeBloc.dispatch(DeleteContact(widget.id));
-              navigation.pop(context);
-            },
-          ),
-        ],
-      ),
     );
   }
 

--- a/lib/src/l10n/localizations.dart
+++ b/lib/src/l10n/localizations.dart
@@ -352,7 +352,7 @@ class AppLocalizations {
 
   String get createGroupTextFieldHint => Intl.message('Set a group name', name: 'createGroupTextFieldHint');
 
-  // Contact
+  // Contacts
   String get contactChangeAddTitle => Intl.message('Add Contact', name: 'contactChangeAddTitle');
 
   String get contactChangeAddToast => Intl.message('Contact successfully added', name: 'contactChangeAddToast');
@@ -388,7 +388,7 @@ class AppLocalizations {
 
   String get contactsSearchHint => Intl.message('Search contacts', name: 'contactsSearchHint');
 
-  //BlockedContacts
+  // Blocked contacts
   String get blockedContactsTitle => Intl.message('Blocked contacts', name: 'blockedContactsTitle');
 
   String get unblockDialogTitle => Intl.message('Unblock contact', name: 'unblockDialogTitle');
@@ -432,7 +432,7 @@ class AppLocalizations {
   // Security settings
   String get securitySettingsExportKeys => Intl.message('Export keys', name: 'securitySettingsExportKeys');
 
-  String get securitySettingsExportKeysText => Intl.message('Use this keys to enable another device to use your current security setup', name: 'securitySettingsExportKeysText');
+  String get securitySettingsExportKeysText => Intl.message('This keys enable another device to use your current encryption setup. Keys are saved on your local storage', name: 'securitySettingsExportKeysText');
 
   String securitySettingsExportKeysDialog(path) => Intl.message('Do you want to save your keys in "$path"?', name: 'securitySettingsExportKeysDialog', args: [path]);
 
@@ -440,9 +440,9 @@ class AppLocalizations {
 
   String get securitySettingsImportKeys => Intl.message('Import keys', name: 'securitySettingsImportKeys');
 
-  String get securitySettingsImportKeysText => Intl.message('Load keys from your local storage to change your current security setup', name: 'securitySettingsImportKeysText');
+  String get securitySettingsImportKeysText => Intl.message('Import keys from your local storage to change your current encryption setup', name: 'securitySettingsImportKeysText');
 
-  String securitySettingsImportKeysDialog(path) => Intl.message('Do you want to load your keys from "$path"? If there are no keys in that folder, the operation will fail.', name: 'securitySettingsImportKeysDialog', args: [path]);
+  String securitySettingsImportKeysDialog(path) => Intl.message('Do you want to import your keys from "$path"? If there are no keys present in that folder, the operation will fail.', name: 'securitySettingsImportKeysDialog', args: [path]);
 
   String get securitySettingsImportKeysPerforming => Intl.message('Performing key import', name: 'securitySettingsImportKeysPerforming');
 
@@ -452,13 +452,50 @@ class AppLocalizations {
 
   String get securitySettingsKeyActionFailedNoPermission => Intl.message('Key action failed, missing permissions', name: 'securitySettingsKeyActionFailedNoPermission');
   
+  String get securitySettingsInitiateKeyTransfer => Intl.message('Initiate key transfer', name: 'securitySettingsInitiateKeyTransfer');
+
+  String get securitySettingsInitiateKeyTransferPerforming => Intl.message('Performing key transfer', name: 'securitySettingsInitiateKeyTransferPerforming');
+
+  String get securitySettingsInitiateKeyTransferText => Intl.message('Creates an Autocrypt Setup Message on the server, you can load on other devices to use your current encryption setup.', name: 'securitySettingsInitiateKeyTransferText');
+
+  String get securitySettingsInitiateKeyTransferDialog => Intl.message('An Autocrypt Setup Message securely shares your end-to-end setup with other Autocrypt-compliant apps. '
+      'The setup will be encrypted by a setup code which is displayed here and must be typed on the other device', name: 'securitySettingsInitiateKeyTransferDialog');
+
+  String get securitySettingsInitiateKeyTransferDone => Intl.message('Setup message created', name: 'securitySettingsInitiateKeyTransferDone');
+
+  String securitySettingsInitiateKeyTransferDoneDialog(setupCode) => Intl.message('Your key has been sent to yourself. Switch to the other device and '
+      'open the setup message. You should be prompted for a setup code. '
+      'Type the following digits into the prompt:\n$setupCode\n'
+      'Once you\'re done, your other device will be ready to use Autocrypt.', name: 'securitySettingsInitiateKeyTransferDoneDialog', args: [setupCode]);
+
+  String get securitySettingsInitiateKeyTransferCopy => Intl.message('Copy code', name: 'securitySettingsInitiateKeyTransferCopy');
+
+  String get securitySettingsInitiateKeyTransferCopyDone => Intl.message('Code copied to clipboard', name: 'securitySettingsInitiateKeyTransferCopyDone');
+
+  String get securitySettingsAutocryptMessage => Intl.message('This message is an Autocrypt Setup Message. Tap it to start the import process. You will be guided through the process.', name: 'securitySettingsAutocryptMessage');
+
+  String get securitySettingsAutocryptImport => Intl.message('Import Autocrypt message', name: 'securitySettingsAutocryptImport');
+
+  String get securitySettingsAutocryptImportText => Intl.message('To complete the import of the Autocrypt Setup Message please provide the security code '
+      'shown in a dialog during creation of the message. After entering the code below the Autocrypt settings will be applied to your current encryption setup.', name: 'securitySettingsAutocryptImportText');
+
+  String get securitySettingsAutocryptImportLabel => Intl.message('Autocrypt setup code', name: 'securitySettingsAutocryptImportLabel');
+
+  String get securitySettingsAutocryptImportHint => Intl.message('The code can be entered with or without minus signs', name: 'securitySettingsAutocryptImportHint');
+
+  String securitySettingsAutocryptImportCodeHint(setupCodeStart) => Intl.message('The associated setup code starts with: $setupCodeStart', name: 'securitySettingsAutocryptImportCodeHint', args: [setupCodeStart]);
+
+  String get securitySettingsAutocryptImportSuccess => Intl.message('Autocrypt setup successfully changed', name: 'securitySettingsAutocryptImportSuccess');
+
+  String get securitySettingsAutocryptImportFailed => Intl.message('Autocrypt setup adjustment failed. Please check the entered setup code.', name: 'securitySettingsAutocryptImportFailed');
+
+  // Notifications
+  String get moreMessages => Intl.message('more messages', name: 'moreMessages');
+
   // About
   String get aboutSettingsName => Intl.message('App name', name: 'aboutSettingsName');
 
   String get aboutSettingsVersion => Intl.message('App version', name: 'aboutSettingsVersion');
-  
-  // Notifications
-  String get moreMessages => Intl.message('more messages', name: 'moreMessages');
 
 }
 

--- a/lib/src/login/login.dart
+++ b/lib/src/login/login.dart
@@ -74,26 +74,39 @@ class _LoginState extends State<Login> {
     hintText: (context) => AppLocalizations.of(context).loginHintEmail,
     textFormType: TextFormType.email,
     inputType: TextInputType.emailAddress,
+    needValidation: true,
+    validationHint: (context) => AppLocalizations.of(context).validatableTextFormFieldHintInvalidEmail,
   );
   ValidatableTextFormField passwordField = ValidatableTextFormField(
     (context) => AppLocalizations.of(context).password,
     hintText: (context) => AppLocalizations.of(context).loginHintPassword,
     textFormType: TextFormType.password,
+    needValidation: true,
+    validationHint: (context) => AppLocalizations.of(context).validatableTextFormFieldHintInvalidPassword,
   );
   ValidatableTextFormField imapLoginNameField = ValidatableTextFormField((context) => AppLocalizations.of(context).loginLabelImapName);
   ValidatableTextFormField imapServerField = ValidatableTextFormField((context) => AppLocalizations.of(context).loginLabelImapServer);
-  ValidatableTextFormField imapPortField = ValidatableTextFormField((context) => AppLocalizations.of(context).loginLabelImapPort);
+  ValidatableTextFormField imapPortField = ValidatableTextFormField(
+    (context) => AppLocalizations.of(context).loginLabelImapPort,
+    textFormType: TextFormType.port,
+    inputType: TextInputType.number,
+    needValidation: true,
+    validationHint: (context) => AppLocalizations.of(context).validatableTextFormFieldHintInvalidPort,
+  );
   ValidatableTextFormField smtpLoginNameField = ValidatableTextFormField((context) => AppLocalizations.of(context).loginLabelSmtpName);
   ValidatableTextFormField smtpPasswordField = ValidatableTextFormField(
     (context) => AppLocalizations.of(context).loginLabelSmtpPassword,
     textFormType: TextFormType.password,
-    needValidation: false,
+    needValidation: true,
+    validationHint: (context) => AppLocalizations.of(context).validatableTextFormFieldHintInvalidPassword,
   );
   ValidatableTextFormField smtpServerField = ValidatableTextFormField((context) => AppLocalizations.of(context).loginLabelSmtpServer);
   ValidatableTextFormField smtpPortField = ValidatableTextFormField(
     (context) => AppLocalizations.of(context).loginLabelSmtpPort,
     textFormType: TextFormType.port,
-    inputType: TextInputType.numberWithOptions(),
+    inputType: TextInputType.number,
+    needValidation: true,
+    validationHint: (context) => AppLocalizations.of(context).validatableTextFormFieldHintInvalidPort,
   );
 
   String _selectedImapSecurity;

--- a/lib/src/message/message_action.dart
+++ b/lib/src/message/message_action.dart
@@ -40,25 +40,14 @@
  * for more details.
  */
 
-import 'package:meta/meta.dart';
-import 'package:ox_coi/src/settings/settings_security_state.dart';
+import 'package:flutter/widgets.dart';
 
-abstract class SettingsSecurityEvent {}
+enum MessageActionTag { forward, copy, delete }
 
-class ExportKeys extends SettingsSecurityEvent {}
+class MessageAction {
+  final String title;
+  final IconData icon;
+  final MessageActionTag messageActionTag;
 
-class ImportKeys extends SettingsSecurityEvent {}
-
-class InitiateKeyTransfer extends SettingsSecurityEvent {}
-
-class ActionSuccess extends SettingsSecurityEvent {
-  String setupCode;
-
-  ActionSuccess({this.setupCode});
-}
-
-class ActionFailed extends SettingsSecurityEvent {
-  final SettingsSecurityStateError error;
-
-  ActionFailed({@required this.error});
+  const MessageAction({this.title, this.icon, this.messageActionTag});
 }

--- a/lib/src/message/message_builder_mixin.dart
+++ b/lib/src/message/message_builder_mixin.dart
@@ -1,0 +1,172 @@
+/*
+ * OPEN-XCHANGE legal information
+ *
+ * All intellectual property rights in the Software are protected by
+ * international copyright laws.
+ *
+ *
+ * In some countries OX, OX Open-Xchange and open xchange
+ * as well as the corresponding Logos OX Open-Xchange and OX are registered
+ * trademarks of the OX Software GmbH group of companies.
+ * The use of the Logos is not covered by the Mozilla Public License 2.0 (MPL 2.0).
+ * Instead, you are allowed to use these Logos according to the terms and
+ * conditions of the Creative Commons License, Version 2.5, Attribution,
+ * Non-commercial, ShareAlike, and the interpretation of the term
+ * Non-commercial applicable to the aforementioned license is published
+ * on the web site https://www.open-xchange.com/terms-and-conditions/.
+ *
+ * Please make sure that third-party modules and libraries are used
+ * according to their respective licenses.
+ *
+ * Any modifications to this package must retain all copyright notices
+ * of the original copyright holder(s) for the original code used.
+ *
+ * After any such modifications, the original and derivative code shall remain
+ * under the copyright of the copyright holder(s) and/or original author(s) as stated here:
+ * https://www.open-xchange.com/legal/. The contributing author shall be
+ * given Attribution for the derivative code and a license granting use.
+ *
+ * Copyright (C) 2016-2020 OX Software GmbH
+ * Mail: info@open-xchange.com
+ *
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public License 2.0
+ * for more details.
+ */
+
+import 'dart:io';
+
+import 'package:delta_chat_core/delta_chat_core.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+import 'package:ox_coi/src/message/message_item_state.dart';
+import 'package:ox_coi/src/utils/conversion.dart';
+import 'package:ox_coi/src/utils/dimensions.dart';
+import 'package:ox_coi/src/utils/styles.dart';
+
+mixin MessageBuilder {
+  Widget buildTextMessage(String text, String time, [int state]) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.end,
+      mainAxisSize: MainAxisSize.min,
+      children: <Widget>[
+        Flexible(
+          child: Text(
+            text,
+            style: defaultText,
+          ),
+        ),
+        Padding(padding: EdgeInsets.only(left: messagesContentTimePadding)),
+        buildTime(time),
+        _buildStateMarker(state),
+      ],
+    );
+  }
+
+  Widget _buildStateMarker(int state) {
+    switch(state){
+      case ChatMsg.messageStateDelivered:
+        return Padding(
+          padding: EdgeInsets.only(left: iconTextPadding),
+          child: Icon(Icons.done, size: 14.0,),
+        );
+        break;
+      case ChatMsg.messageStateReceived:
+        return Padding(
+          padding: EdgeInsets.only(left: iconTextPadding),
+          child: Icon(Icons.done_all, size: 14.0,),
+        );
+        break;
+      default:
+        return Container();
+    }
+  }
+
+  StatelessWidget buildTime(String time) {
+    return Text(time, style: messageTimeText);
+  }
+
+  Widget buildAttachmentMessage(AttachmentWrapper attachment, String text, String time, [int state]) {
+    return Container(
+      child: attachment.type == ChatMsg.typeImage
+          ? buildImageAttachmentMessage(attachment, text, time, state)
+          : buildGenericAttachmentMessage(attachment, time, state),
+    );
+  }
+
+  Widget buildImageAttachmentMessage(AttachmentWrapper attachment, String text, String time, [int state]) {
+    File file = File(attachment.path);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.end,
+      mainAxisSize: MainAxisSize.min,
+      children: <Widget>[
+        Image.file(file),
+        text.isNotEmpty ? Padding(padding: EdgeInsets.only(top: messagesContentTimePadding)) : Container(),
+        text.isNotEmpty
+            ? Flexible(
+                child: Text(text),
+              )
+            : Container(),
+        Padding(padding: EdgeInsets.only(top: messagesContentTimePadding)),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.end,
+          children: <Widget>[
+            buildTime(time),
+            _buildStateMarker(state),
+          ],
+        ),
+      ],
+    );
+  }
+
+  Row buildGenericAttachmentMessage(AttachmentWrapper attachment, String time, [int state]) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.end,
+      mainAxisSize: MainAxisSize.min,
+      children: <Widget>[
+        Icon(
+          Icons.attach_file,
+          size: messagesFileIconSize,
+        ),
+        Flexible(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisAlignment: MainAxisAlignment.start,
+            children: <Widget>[
+              Text(
+                attachment.filename,
+                softWrap: true,
+                overflow: TextOverflow.ellipsis,
+              ),
+              Text(byteToPrintableSize(attachment.size)),
+            ],
+          ),
+        ),
+        Padding(padding: EdgeInsets.only(left: messagesContentTimePadding)),
+        buildTime(time),
+        _buildStateMarker(state),
+      ],
+    );
+  }
+
+  BoxDecoration buildBoxDecoration(Color shadowColor, Color backgroundColor, BorderRadius borderRadius) {
+    return BoxDecoration(
+      shape: BoxShape.rectangle,
+      boxShadow: [
+        new BoxShadow(
+          color: shadowColor,
+          blurRadius: messagesBlurRadius,
+        ),
+      ],
+      color: backgroundColor,
+      borderRadius: borderRadius,
+    );
+  }
+
+}

--- a/lib/src/message/message_item_bloc.dart
+++ b/lib/src/message/message_item_bloc.dart
@@ -89,6 +89,8 @@ class MessageItemBloc extends Bloc<MessageItemEvent, MessageItemState> {
       bool isOutgoing = await message.isOutgoing();
       String text = await message.getText();
       bool hasFile = await message.hasFile();
+      bool isSetupMessage = await message.isSetupMessage();
+      bool isInfo = await message.isInfo();
       int timestamp = await message.getTimestamp();
       int state = await message.getState();
       AttachmentWrapper attachmentWrapper;
@@ -119,6 +121,8 @@ class MessageItemBloc extends Bloc<MessageItemEvent, MessageItemState> {
           messageIsOutgoing: isOutgoing,
           messageText: text,
           hasFile: hasFile,
+          isSetupMessage: isSetupMessage,
+          isInfo: isInfo,
           messageTimestamp: timestamp,
           state: state,
           attachmentWrapper: attachmentWrapper,
@@ -129,6 +133,8 @@ class MessageItemBloc extends Bloc<MessageItemEvent, MessageItemState> {
           messageIsOutgoing: isOutgoing,
           messageText: text,
           hasFile: hasFile,
+          isSetupMessage: isSetupMessage,
+          isInfo: isInfo,
           messageTimestamp: timestamp,
           state: state,
           attachmentWrapper: attachmentWrapper,

--- a/lib/src/message/message_item_state.dart
+++ b/lib/src/message/message_item_state.dart
@@ -56,6 +56,8 @@ class MessageItemStateSuccess extends MessageItemState {
   final bool messageIsOutgoing;
   final bool hasFile;
   final int state;
+  final bool isSetupMessage;
+  final bool isInfo;
   final ContactWrapper contactWrapper;
   final AttachmentWrapper attachmentWrapper;
 
@@ -65,6 +67,8 @@ class MessageItemStateSuccess extends MessageItemState {
     @required this.messageTimestamp,
     @required this.hasFile,
     @required this.state,
+    @required this.isSetupMessage,
+    @required this.isInfo,
     @required this.attachmentWrapper,
     @required this.contactWrapper,
   });

--- a/lib/src/message/message_received_view.dart
+++ b/lib/src/message/message_received_view.dart
@@ -1,0 +1,109 @@
+/*
+ * OPEN-XCHANGE legal information
+ *
+ * All intellectual property rights in the Software are protected by
+ * international copyright laws.
+ *
+ *
+ * In some countries OX, OX Open-Xchange and open xchange
+ * as well as the corresponding Logos OX Open-Xchange and OX are registered
+ * trademarks of the OX Software GmbH group of companies.
+ * The use of the Logos is not covered by the Mozilla Public License 2.0 (MPL 2.0).
+ * Instead, you are allowed to use these Logos according to the terms and
+ * conditions of the Creative Commons License, Version 2.5, Attribution,
+ * Non-commercial, ShareAlike, and the interpretation of the term
+ * Non-commercial applicable to the aforementioned license is published
+ * on the web site https://www.open-xchange.com/terms-and-conditions/.
+ *
+ * Please make sure that third-party modules and libraries are used
+ * according to their respective licenses.
+ *
+ * Any modifications to this package must retain all copyright notices
+ * of the original copyright holder(s) for the original code used.
+ *
+ * After any such modifications, the original and derivative code shall remain
+ * under the copyright of the copyright holder(s) and/or original author(s) as stated here:
+ * https://www.open-xchange.com/legal/. The contributing author shall be
+ * given Attribution for the derivative code and a license granting use.
+ *
+ * Copyright (C) 2016-2020 OX Software GmbH
+ * Mail: info@open-xchange.com
+ *
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public License 2.0
+ * for more details.
+ */
+
+import 'package:flutter/widgets.dart';
+import 'package:ox_coi/src/message/message_builder_mixin.dart';
+import 'package:ox_coi/src/message/message_item_state.dart';
+import 'package:ox_coi/src/utils/colors.dart';
+import 'package:ox_coi/src/utils/date.dart';
+import 'package:ox_coi/src/utils/dimensions.dart';
+import 'package:ox_coi/src/widgets/avatar.dart';
+
+class MessageReceived extends StatelessWidget with MessageBuilder {
+  final String name;
+  final String email;
+  final Color color;
+  final String text;
+  final int timestamp;
+  final bool hasFile;
+  final bool isGroupChat;
+  final AttachmentWrapper attachmentWrapper;
+
+  const MessageReceived(
+      {Key key, this.name, this.email, this.color, this.text, this.timestamp, this.hasFile, this.isGroupChat, this.attachmentWrapper})
+      : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    String time = getTimeFormTimestamp(timestamp);
+    return FractionallySizedBox(
+      alignment: Alignment.topLeft,
+      widthFactor: 0.8,
+      child: Row(
+        children: <Widget>[
+          isGroupChat
+              ? Padding(
+                  padding: const EdgeInsets.only(right: messagesInnerPadding),
+                  child: Avatar(
+                    textPrimary: name,
+                    textSecondary: email,
+                    color: color,
+                  ),
+                )
+              : Container(),
+          Flexible(
+            child: Container(
+              padding: EdgeInsets.all(messagesInnerPadding),
+              decoration: buildBoxDecoration(messageBoxGrey, messageReceivedBackground, buildBorderRadius()),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  isGroupChat ? Text(name, style: TextStyle(color: color)) : Container(constraints: BoxConstraints(maxWidth: zero)),
+                  hasFile ? buildAttachmentMessage(attachmentWrapper, text, time) : buildTextMessage(text, time),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  BorderRadius buildBorderRadius() {
+    return BorderRadius.only(
+      topRight: Radius.circular(messagesBoxRadius),
+      bottomRight: Radius.circular(messagesBoxRadius),
+      bottomLeft: Radius.circular(messagesBoxRadius),
+    );
+  }
+}

--- a/lib/src/message/message_sent_view.dart
+++ b/lib/src/message/message_sent_view.dart
@@ -40,25 +40,48 @@
  * for more details.
  */
 
-import 'package:meta/meta.dart';
-import 'package:ox_coi/src/settings/settings_security_state.dart';
+import 'package:flutter/widgets.dart';
+import 'package:ox_coi/src/message/message_builder_mixin.dart';
+import 'package:ox_coi/src/message/message_item_state.dart';
+import 'package:ox_coi/src/utils/colors.dart';
+import 'package:ox_coi/src/utils/date.dart';
+import 'package:ox_coi/src/utils/dimensions.dart';
 
-abstract class SettingsSecurityEvent {}
+class MessageSent extends StatelessWidget with MessageBuilder {
+  final String text;
+  final int timestamp;
+  final bool hasFile;
+  final int msgState;
+  final AttachmentWrapper attachmentWrapper;
 
-class ExportKeys extends SettingsSecurityEvent {}
+  const MessageSent({Key key, this.text, this.timestamp, this.hasFile, this.msgState, this.attachmentWrapper}) : super(key: key);
 
-class ImportKeys extends SettingsSecurityEvent {}
+  @override
+  Widget build(BuildContext context) {
+    String time = getTimeFormTimestamp(timestamp);
+    return FractionallySizedBox(
+        alignment: Alignment.topRight,
+        widthFactor: 0.8,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.end,
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            Container(
+              decoration: buildBoxDecoration(messageBoxGrey, messageSentBackground, buildBorderRadius()),
+              child: Padding(
+                padding: EdgeInsets.all(messagesInnerPadding),
+                child: hasFile ? buildAttachmentMessage(attachmentWrapper, text, time, msgState) : buildTextMessage(text, time, msgState),
+              ),
+            ),
+          ],
+        ));
+  }
 
-class InitiateKeyTransfer extends SettingsSecurityEvent {}
-
-class ActionSuccess extends SettingsSecurityEvent {
-  String setupCode;
-
-  ActionSuccess({this.setupCode});
-}
-
-class ActionFailed extends SettingsSecurityEvent {
-  final SettingsSecurityStateError error;
-
-  ActionFailed({@required this.error});
+  BorderRadius buildBorderRadius() {
+    return BorderRadius.only(
+      topRight: Radius.circular(messagesBoxRadius),
+      bottomLeft: Radius.circular(messagesBoxRadius),
+      topLeft: Radius.circular(messagesBoxRadius),
+    );
+  }
 }

--- a/lib/src/message/message_special_view.dart
+++ b/lib/src/message/message_special_view.dart
@@ -40,52 +40,68 @@
  * for more details.
  */
 
-import 'dart:io';
-
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+import 'package:ox_coi/src/l10n/localizations.dart';
 import 'package:ox_coi/src/utils/colors.dart';
+import 'package:ox_coi/src/utils/date.dart';
 import 'package:ox_coi/src/utils/dimensions.dart';
-import 'package:ox_coi/src/utils/text.dart';
 
-class Avatar extends StatelessWidget {
-  final String imagePath;
-  final String textPrimary;
-  final String textSecondary;
-  final Color color;
+import 'message_builder_mixin.dart';
 
-  Avatar({this.imagePath, @required this.textPrimary, @required this.textSecondary, this.color});
+class MessageSpecial extends StatelessWidget with MessageBuilder {
+  final bool isSetupMessage;
+  final String messageText;
+  final int timestamp;
+
+  const MessageSpecial({Key key, this.isSetupMessage, this.messageText, this.timestamp}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    String initials;
-    FileImage avatarImage;
-    if (imagePath != null && imagePath.isNotEmpty) {
-      avatarImage = FileImage(File(imagePath));
-    } else {
-      initials = getInitials(textPrimary, textSecondary);
-    }
-    if (avatarImage == null && isNullOrEmpty(initials)) {
-      return Container(
-        height: listAvatarDiameter,
-        width: listAvatarDiameter,
-      );
-    }
-    return CircleAvatar(
-      radius: listAvatarRadius,
-      foregroundColor: listAvatarForegroundColor,
-      backgroundColor: color != null ? color : listAvatarDefaultBackgroundColor,
-      child: avatarImage != null ? avatarImage : new Text(initials),
+    return isSetupMessage ? buildSetupMessage(context) : buildInfoMessage();
+  }
+
+  Widget buildSetupMessage(BuildContext context) {
+    String time = getTimeFormTimestamp(timestamp);
+    String text = AppLocalizations.of(context).securitySettingsAutocryptMessage;
+    return FractionallySizedBox(
+        alignment: Alignment.topRight,
+        widthFactor: 0.8,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.end,
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            Container(
+              decoration: buildBoxDecoration(messageBoxGrey, messageSetupBackground, buildBorderRadius()),
+              child: Padding(
+                padding: EdgeInsets.all(messagesInnerPadding),
+                child: buildTextMessage(text, time),
+              ),
+            ),
+          ],
+        ));
+  }
+
+  Widget buildInfoMessage() {
+    return Center(
+      child: Container(
+        decoration: buildBoxDecoration(messageBoxGrey, messageInfoBackground, buildInfoBorderRadius()),
+        child: Padding(
+          padding: EdgeInsets.all(messagesInnerPadding),
+          child: Text(messageText),
+        ),
+      ),
     );
   }
 
-  static String getInitials(String textPrimary, String textSecondary) {
-    if (textPrimary != null && textPrimary.isNotEmpty) {
-      return textPrimary.substring(0, 1);
-    }
-    if (textSecondary != null && textSecondary.isNotEmpty) {
-      return textSecondary.substring(0, 1);
-    }
-    return "";
+  BorderRadius buildBorderRadius() {
+    return BorderRadius.only(
+      topRight: Radius.circular(messagesBoxRadius),
+      bottomLeft: Radius.circular(messagesBoxRadius),
+      topLeft: Radius.circular(messagesBoxRadius),
+    );
+  }
+
+  BorderRadius buildInfoBorderRadius() {
+    return BorderRadius.all(Radius.circular(messagesBoxRadius));
   }
 }
-

--- a/lib/src/navigation/navigatable.dart
+++ b/lib/src/navigation/navigatable.dart
@@ -71,6 +71,9 @@ enum Type {
   settingsUser,
   settingsExportKeysDialog,
   settingsImportKeysDialog,
+  settingsKeyTransferDialog,
+  settingsKeyTransferDoneDialog,
+  settingsAutocryptImport,
   splash,
 }
 

--- a/lib/src/settings/settings_autocrypt_bloc.dart
+++ b/lib/src/settings/settings_autocrypt_bloc.dart
@@ -1,0 +1,92 @@
+/*
+ * OPEN-XCHANGE legal information
+ *
+ * All intellectual property rights in the Software are protected by
+ * international copyright laws.
+ *
+ *
+ * In some countries OX, OX Open-Xchange and open xchange
+ * as well as the corresponding Logos OX Open-Xchange and OX are registered
+ * trademarks of the OX Software GmbH group of companies.
+ * The use of the Logos is not covered by the Mozilla Public License 2.0 (MPL 2.0).
+ * Instead, you are allowed to use these Logos according to the terms and
+ * conditions of the Creative Commons License, Version 2.5, Attribution,
+ * Non-commercial, ShareAlike, and the interpretation of the term
+ * Non-commercial applicable to the aforementioned license is published
+ * on the web site https://www.open-xchange.com/terms-and-conditions/.
+ *
+ * Please make sure that third-party modules and libraries are used
+ * according to their respective licenses.
+ *
+ * Any modifications to this package must retain all copyright notices
+ * of the original copyright holder(s) for the original code used.
+ *
+ * After any such modifications, the original and derivative code shall remain
+ * under the copyright of the copyright holder(s) and/or original author(s) as stated here:
+ * https://www.open-xchange.com/legal/. The contributing author shall be
+ * given Attribution for the derivative code and a license granting use.
+ *
+ * Copyright (C) 2016-2020 OX Software GmbH
+ * Mail: info@open-xchange.com
+ *
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public License 2.0
+ * for more details.
+ */
+
+import 'dart:async';
+
+import 'package:bloc/bloc.dart';
+import 'package:delta_chat_core/delta_chat_core.dart';
+import 'package:ox_coi/src/data/chat_message_repository.dart';
+import 'package:ox_coi/src/data/repository_manager.dart';
+import 'package:ox_coi/src/settings/settings_autocrypt_event.dart';
+import 'package:ox_coi/src/settings/settings_autocrypt_state.dart';
+
+class SettingsAutocryptBloc extends Bloc<SettingsAutocryptEvent, SettingsAutocryptState> {
+  @override
+  SettingsAutocryptState get initialState => SettingsAutocryptStateInitial();
+
+  @override
+  Stream<SettingsAutocryptState> mapEventToState(SettingsAutocryptState currentState, SettingsAutocryptEvent event) async* {
+    if (event is PrepareKeyTransfer) {
+      _prepareKeyTransfer(event.chatId, event.messageId);
+    } else if (event is KeyTransferPrepared) {
+      yield SettingsAutocryptStatePrepared(setupCodeStart: event.setupCodeStart);
+    } else if (event is ContinueKeyTransfer) {
+      yield SettingsAutocryptStateLoading();
+      try {
+        _continueKeyTransfer(event.messageId, event.setupCode);
+      } catch (error) {
+        yield SettingsAutocryptStateFailure();
+      }
+    } else if (event is KeyTransferDone) {
+      yield SettingsAutocryptStateSuccess();
+    } else if (event is KeyTransferFailed) {
+      yield SettingsAutocryptStateFailure();
+    }
+  }
+
+  void _prepareKeyTransfer(int chatId, int messageId) async{
+    ChatMessageRepository messageListRepository = RepositoryManager.get(RepositoryType.chatMessage, chatId);
+    ChatMsg chatMsg = messageListRepository.get(messageId);
+    String setupCodeBegin = await chatMsg.getSetupCodeBegin();
+    dispatch(KeyTransferPrepared(setupCodeStart: setupCodeBegin));
+  }
+
+  void _continueKeyTransfer(int messageId, String setupCode) async {
+    Context context = Context();
+    bool transferSuccess = await context.continueKeyTransfer(messageId, setupCode);
+    if (transferSuccess) {
+      dispatch(KeyTransferDone());
+    } else {
+      dispatch(KeyTransferFailed());
+    }
+  }
+}

--- a/lib/src/settings/settings_autocrypt_event.dart
+++ b/lib/src/settings/settings_autocrypt_event.dart
@@ -41,24 +41,29 @@
  */
 
 import 'package:meta/meta.dart';
-import 'package:ox_coi/src/settings/settings_security_state.dart';
 
-abstract class SettingsSecurityEvent {}
+abstract class SettingsAutocryptEvent {}
 
-class ExportKeys extends SettingsSecurityEvent {}
+class PrepareKeyTransfer extends SettingsAutocryptEvent {
+  final int chatId;
+  final int messageId;
 
-class ImportKeys extends SettingsSecurityEvent {}
-
-class InitiateKeyTransfer extends SettingsSecurityEvent {}
-
-class ActionSuccess extends SettingsSecurityEvent {
-  String setupCode;
-
-  ActionSuccess({this.setupCode});
+  PrepareKeyTransfer({@required this.chatId, @required this.messageId});
 }
 
-class ActionFailed extends SettingsSecurityEvent {
-  final SettingsSecurityStateError error;
+class ContinueKeyTransfer extends SettingsAutocryptEvent {
+  final int messageId;
+  final String setupCode;
 
-  ActionFailed({@required this.error});
+  ContinueKeyTransfer({@required this.messageId, @required this.setupCode});
 }
+
+class KeyTransferPrepared extends SettingsAutocryptEvent {
+  final String setupCodeStart;
+
+  KeyTransferPrepared({@required this.setupCodeStart});
+}
+
+class KeyTransferDone extends SettingsAutocryptEvent {}
+
+class KeyTransferFailed extends SettingsAutocryptEvent {}

--- a/lib/src/settings/settings_autocrypt_import.dart
+++ b/lib/src/settings/settings_autocrypt_import.dart
@@ -1,0 +1,160 @@
+/*
+ * OPEN-XCHANGE legal information
+ *
+ * All intellectual property rights in the Software are protected by
+ * international copyright laws.
+ *
+ *
+ * In some countries OX, OX Open-Xchange and open xchange
+ * as well as the corresponding Logos OX Open-Xchange and OX are registered
+ * trademarks of the OX Software GmbH group of companies.
+ * The use of the Logos is not covered by the Mozilla Public License 2.0 (MPL 2.0).
+ * Instead, you are allowed to use these Logos according to the terms and
+ * conditions of the Creative Commons License, Version 2.5, Attribution,
+ * Non-commercial, ShareAlike, and the interpretation of the term
+ * Non-commercial applicable to the aforementioned license is published
+ * on the web site https://www.open-xchange.com/terms-and-conditions/.
+ *
+ * Please make sure that third-party modules and libraries are used
+ * according to their respective licenses.
+ *
+ * Any modifications to this package must retain all copyright notices
+ * of the original copyright holder(s) for the original code used.
+ *
+ * After any such modifications, the original and derivative code shall remain
+ * under the copyright of the copyright holder(s) and/or original author(s) as stated here:
+ * https://www.open-xchange.com/legal/. The contributing author shall be
+ * given Attribution for the derivative code and a license granting use.
+ *
+ * Copyright (C) 2016-2020 OX Software GmbH
+ * Mail: info@open-xchange.com
+ *
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public License 2.0
+ * for more details.
+ */
+
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:ox_coi/src/l10n/localizations.dart';
+import 'package:ox_coi/src/navigation/navigatable.dart';
+import 'package:ox_coi/src/navigation/navigation.dart';
+import 'package:ox_coi/src/settings/settings_autocrypt_bloc.dart';
+import 'package:ox_coi/src/settings/settings_autocrypt_event.dart';
+import 'package:ox_coi/src/settings/settings_autocrypt_state.dart';
+import 'package:ox_coi/src/utils/colors.dart';
+import 'package:ox_coi/src/utils/dimensions.dart';
+import 'package:ox_coi/src/utils/toast.dart';
+import 'package:ox_coi/src/widgets/validatable_text_form_field.dart';
+import 'package:rxdart/rxdart.dart';
+
+class SettingsAutocryptImport extends StatefulWidget {
+  final int chatId;
+  final int messageId;
+
+  const SettingsAutocryptImport({Key key, this.chatId, this.messageId}) : super(key: key);
+
+  @override
+  _SettingsAutocryptImportState createState() => _SettingsAutocryptImportState();
+}
+
+class _SettingsAutocryptImportState extends State<SettingsAutocryptImport> {
+  SettingsAutocryptBloc _settingsAutocryptBloc = SettingsAutocryptBloc();
+  Navigation navigation = Navigation();
+  GlobalKey<FormState> _formKey = GlobalKey();
+  ValidatableTextFormField _setupCodeField;
+  String setupCodeStart;
+
+  @override
+  void initState() {
+    super.initState();
+    final contactImportObservable = new Observable<SettingsAutocryptState>(_settingsAutocryptBloc.state);
+    contactImportObservable.listen((state) => handleAutocryptImport(state));
+    _settingsAutocryptBloc.dispatch(PrepareKeyTransfer(chatId: widget.chatId, messageId: widget.messageId));
+    navigation.current = Navigatable(Type.settingsAutocryptImport);
+  }
+
+  void handleAutocryptImport(SettingsAutocryptState state) {
+    if (state is SettingsAutocryptStatePrepared) {
+      _setupCodeField = ValidatableTextFormField(
+        (context) => AppLocalizations.of(context).securitySettingsAutocryptImportLabel,
+        hintText: (context) => AppLocalizations.of(context).securitySettingsAutocryptImportHint,
+        inputType: TextInputType.number,
+        maxLines: 2,
+        needValidation: true,
+        validationHint: (context) => AppLocalizations.of(context).validatableTextFormFieldHintEmptyString,
+      );
+      setupCodeStart = state.setupCodeStart;
+    } else if (state is SettingsAutocryptStateFailure) {
+      showToast(AppLocalizations.of(context).securitySettingsAutocryptImportFailed);
+    } else if (state is SettingsAutocryptStateSuccess) {
+      showToast(AppLocalizations.of(context).securitySettingsAutocryptImportSuccess);
+      navigation.pop(context);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        leading: new IconButton(
+          icon: new Icon(Icons.close),
+          onPressed: () => navigation.pop(context),
+        ),
+        backgroundColor: contactMain,
+        title: Text(AppLocalizations.of(context).securitySettingsAutocryptImport),
+        actions: <Widget>[
+          IconButton(
+            icon: Icon(Icons.check),
+            onPressed: () => onSubmit(),
+          )
+        ],
+      ),
+      body: BlocBuilder(
+        bloc: _settingsAutocryptBloc,
+        builder: (context, state) {
+          if (state is SettingsAutocryptStatePrepared || state is SettingsAutocryptStateFailure) {
+            return buildForm();
+          } else {
+            return Center(child: CircularProgressIndicator());
+          }
+        },
+      ),
+    );
+  }
+
+  onSubmit() {
+    if (_formKey.currentState.validate()) {
+      _settingsAutocryptBloc.dispatch(ContinueKeyTransfer(messageId: widget.messageId, setupCode: _setupCodeField.controller.text));
+    }
+  }
+
+  Widget buildForm() {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: formHorizontalPadding, vertical: formVerticalPadding),
+      child: Form(
+        key: _formKey,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Padding(
+              padding: const EdgeInsets.only(bottom: formVerticalPadding),
+              child: Text(AppLocalizations.of(context).securitySettingsAutocryptImportText),
+            ),
+            Padding(
+              padding: const EdgeInsets.only(bottom: formVerticalPadding),
+              child: Text(AppLocalizations.of(context).securitySettingsAutocryptImportCodeHint(setupCodeStart)),
+            ),
+            _setupCodeField,
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/settings/settings_autocrypt_state.dart
+++ b/lib/src/settings/settings_autocrypt_state.dart
@@ -41,24 +41,19 @@
  */
 
 import 'package:meta/meta.dart';
-import 'package:ox_coi/src/settings/settings_security_state.dart';
 
-abstract class SettingsSecurityEvent {}
+abstract class SettingsAutocryptState {}
 
-class ExportKeys extends SettingsSecurityEvent {}
+class SettingsAutocryptStateInitial extends SettingsAutocryptState {}
 
-class ImportKeys extends SettingsSecurityEvent {}
+class SettingsAutocryptStateLoading extends SettingsAutocryptState {}
 
-class InitiateKeyTransfer extends SettingsSecurityEvent {}
+class SettingsAutocryptStatePrepared extends SettingsAutocryptState {
+  final String setupCodeStart;
 
-class ActionSuccess extends SettingsSecurityEvent {
-  String setupCode;
-
-  ActionSuccess({this.setupCode});
+  SettingsAutocryptStatePrepared({@required this.setupCodeStart});
 }
 
-class ActionFailed extends SettingsSecurityEvent {
-  final SettingsSecurityStateError error;
+class SettingsAutocryptStateSuccess extends SettingsAutocryptState {}
 
-  ActionFailed({@required this.error});
-}
+class SettingsAutocryptStateFailure extends SettingsAutocryptState {}

--- a/lib/src/settings/settings_security_state.dart
+++ b/lib/src/settings/settings_security_state.dart
@@ -57,7 +57,11 @@ class SettingsSecurityStateLoading extends SettingsSecurityState {
   SettingsSecurityStateLoading({@required this.type});
 }
 
-class SettingsSecurityStateSuccess extends SettingsSecurityState {}
+class SettingsSecurityStateSuccess extends SettingsSecurityState {
+  String setupCode;
+
+  SettingsSecurityStateSuccess({this.setupCode});
+}
 
 class SettingsSecurityStateFailure extends SettingsSecurityState {
   final SettingsSecurityStateError error;

--- a/lib/src/share/share.dart
+++ b/lib/src/share/share.dart
@@ -46,7 +46,7 @@ import 'package:ox_coi/src/chat/chat.dart';
 import 'package:ox_coi/src/chatlist/chat_list_item.dart';
 import 'package:ox_coi/src/contact/contact_item.dart';
 import 'package:ox_coi/src/l10n/localizations.dart';
-import 'package:ox_coi/src/message/message_item.dart';
+import 'package:ox_coi/src/message/message_action.dart';
 import 'package:ox_coi/src/navigation/navigation.dart';
 import 'package:ox_coi/src/share/share_bloc.dart';
 import 'package:ox_coi/src/share/share_event.dart';

--- a/lib/src/user/user_account_settings.dart
+++ b/lib/src/user/user_account_settings.dart
@@ -86,24 +86,31 @@ class _UserAccountSettingsState extends State<UserAccountSettings> {
   ValidatableTextFormField imapPasswordField = ValidatableTextFormField(
     (context) => AppLocalizations.of(context).password,
     textFormType: TextFormType.password,
+    needValidation: true,
+    validationHint: (context) => AppLocalizations.of(context).validatableTextFormFieldHintInvalidPassword,
   );
   ValidatableTextFormField imapServerField = ValidatableTextFormField((context) => AppLocalizations.of(context).loginLabelImapServer);
   ValidatableTextFormField imapPortField = ValidatableTextFormField(
     (context) => AppLocalizations.of(context).loginLabelImapPort,
     textFormType: TextFormType.port,
-    inputType: TextInputType.numberWithOptions(),
+    inputType: TextInputType.number,
+    needValidation: true,
+    validationHint: (context) => AppLocalizations.of(context).validatableTextFormFieldHintInvalidPort,
   );
   ValidatableTextFormField smtpLoginNameField = ValidatableTextFormField((context) => AppLocalizations.of(context).loginLabelSmtpName);
   ValidatableTextFormField smtpPasswordField = ValidatableTextFormField(
     (context) => AppLocalizations.of(context).loginLabelSmtpPassword,
     textFormType: TextFormType.password,
-    needValidation: false,
+    needValidation: true,
+    validationHint: (context) => AppLocalizations.of(context).validatableTextFormFieldHintInvalidPassword,
   );
   ValidatableTextFormField smtpServerField = ValidatableTextFormField((context) => AppLocalizations.of(context).loginLabelSmtpServer);
   ValidatableTextFormField smtpPortField = ValidatableTextFormField(
     (context) => AppLocalizations.of(context).loginLabelSmtpPort,
     textFormType: TextFormType.port,
-    inputType: TextInputType.numberWithOptions(),
+    inputType: TextInputType.number,
+    needValidation: true,
+    validationHint: (context) => AppLocalizations.of(context).validatableTextFormFieldHintInvalidPort,
   );
   String _selectedImapSecurity;
   String _selectedSmtpSecurity;

--- a/lib/src/user/user_profile.dart
+++ b/lib/src/user/user_profile.dart
@@ -57,6 +57,7 @@ import 'package:ox_coi/src/utils/colors.dart';
 import 'package:ox_coi/src/utils/dimensions.dart';
 import 'package:ox_coi/src/utils/styles.dart';
 import 'package:ox_coi/src/utils/widgets.dart';
+import 'package:ox_coi/src/widgets/placeholder_text.dart';
 
 class UserProfileView extends RootChild {
   UserProfileView(State<StatefulWidget> state) : super(state);
@@ -131,7 +132,7 @@ class _ProfileState extends State<UserProfileView> {
               padding: EdgeInsets.symmetric(vertical: profileSectionsVerticalPadding),
               child: buildAvatar(config),
             ),
-            buildTextOrPlaceHolder(
+            PlaceholderText(
               text: config.username,
               style: hugeText,
               align: TextAlign.center,
@@ -148,7 +149,7 @@ class _ProfileState extends State<UserProfileView> {
             ),
             Padding(
               padding: const EdgeInsets.symmetric(vertical: profileSectionsVerticalPadding),
-              child: buildTextOrPlaceHolder(
+              child: PlaceholderText(
                 text: config.status,
                 align: TextAlign.center,
                 style: defaultText,
@@ -157,11 +158,12 @@ class _ProfileState extends State<UserProfileView> {
                 placeHolderAlign: TextAlign.center,
               ),
             ),
-            buildOutlineButton(
-              context: context,
-              color: accent,
-              child: Text(AppLocalizations.of(context).profileEditButton),
+            OutlineButton(
+              highlightedBorderColor: accent,
+              borderSide: BorderSide(color: accent),
+              textColor: accent,
               onPressed: editUserSettings,
+              child: Text(AppLocalizations.of(context).profileEditButton),
             ),
           ],
         ),

--- a/lib/src/utils/colors.dart
+++ b/lib/src/utils/colors.dart
@@ -94,6 +94,8 @@ const Color messageBoxGrey = Colors.grey;
 final Color messageSentBackground = Colors.blue[50];
 const Color messageReceivedBackground = Colors.white;
 final Color messageTimeForeground = Colors.grey[700];
+const Color messageInfoBackground = Colors.white70;
+final Color messageSetupBackground = Colors.blue[200];
 
 // Mail
 const Color mailMain = Colors.indigo;

--- a/lib/src/utils/text.dart
+++ b/lib/src/utils/text.dart
@@ -40,25 +40,22 @@
  * for more details.
  */
 
-import 'package:meta/meta.dart';
-import 'package:ox_coi/src/settings/settings_security_state.dart';
+isNullOrEmpty(String text) => text == null || text.isEmpty;
 
-abstract class SettingsSecurityEvent {}
-
-class ExportKeys extends SettingsSecurityEvent {}
-
-class ImportKeys extends SettingsSecurityEvent {}
-
-class InitiateKeyTransfer extends SettingsSecurityEvent {}
-
-class ActionSuccess extends SettingsSecurityEvent {
-  String setupCode;
-
-  ActionSuccess({this.setupCode});
+bool isEmail(String email) {
+  String source =
+      r'^(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$';
+  RegExp regExp = new RegExp(source);
+  return regExp.hasMatch(email);
 }
 
-class ActionFailed extends SettingsSecurityEvent {
-  final SettingsSecurityStateError error;
-
-  ActionFailed({@required this.error});
+bool isPort(String portString) {
+  if (portString.isEmpty) {
+    return true;
+  }
+  int port = int.tryParse(portString);
+  if (port == null || port < 1 || port >= 65535) {
+    return false;
+  }
+  return true;
 }

--- a/lib/src/utils/widgets.dart
+++ b/lib/src/utils/widgets.dart
@@ -49,39 +49,3 @@ Key createKey(var value) {
     return Key(value.toString());
   }
 }
-
-OutlineButton buildOutlineButton({
-  BuildContext context,
-  Function onPressed,
-  Widget child,
-  Color color,
-}) {
-  return OutlineButton(
-    highlightedBorderColor: color,
-    borderSide: BorderSide(color: color),
-    textColor: color,
-    onPressed: onPressed,
-    child: child,
-  );
-}
-
-Widget buildTextOrPlaceHolder({
-  @required String text,
-  TextStyle style,
-  TextAlign align,
-  @required String placeholderText,
-  TextStyle placeholderStyle,
-  TextAlign placeHolderAlign,
-}) {
-  return text != null && text.isNotEmpty
-      ? Text(
-          text,
-          style: style,
-          textAlign: align,
-        )
-      : Text(
-          placeholderText,
-          style: placeholderStyle,
-          textAlign: placeHolderAlign,
-        );
-}

--- a/lib/src/widgets/avatar_list_item.dart
+++ b/lib/src/widgets/avatar_list_item.dart
@@ -90,7 +90,8 @@ class AvatarListItem extends StatelessWidget {
             avatarIcon == null
               ? Avatar(
                   imagePath: imagePath,
-                  initials: getInitials(),
+                  textPrimary: title,
+                  textSecondary: subTitle,
                   color: color,
                 )
               : CircleAvatar(
@@ -193,13 +194,4 @@ class AvatarListItem extends StatelessWidget {
     );
   }
 
-  String getInitials() {
-    if (title != null && title.isNotEmpty) {
-      return title.substring(0, 1);
-    }
-    if (subTitle != null && subTitle.isNotEmpty) {
-      return subTitle.substring(0, 1);
-    }
-    return "";
-  }
 }

--- a/lib/src/widgets/placeholder_text.dart
+++ b/lib/src/widgets/placeholder_text.dart
@@ -40,25 +40,38 @@
  * for more details.
  */
 
-import 'package:meta/meta.dart';
-import 'package:ox_coi/src/settings/settings_security_state.dart';
+import 'package:flutter/widgets.dart';
+import 'package:ox_coi/src/utils/text.dart';
 
-abstract class SettingsSecurityEvent {}
+class PlaceholderText extends StatelessWidget {
+  final String text;
+  final TextStyle style;
+  final TextAlign align;
+  final String placeholderText;
+  final TextStyle placeholderStyle;
+  final TextAlign placeHolderAlign;
 
-class ExportKeys extends SettingsSecurityEvent {}
+  PlaceholderText({
+    @required this.text,
+    this.style,
+    this.align,
+    @required this.placeholderText,
+    this.placeholderStyle,
+    this.placeHolderAlign,
+  });
 
-class ImportKeys extends SettingsSecurityEvent {}
-
-class InitiateKeyTransfer extends SettingsSecurityEvent {}
-
-class ActionSuccess extends SettingsSecurityEvent {
-  String setupCode;
-
-  ActionSuccess({this.setupCode});
-}
-
-class ActionFailed extends SettingsSecurityEvent {
-  final SettingsSecurityStateError error;
-
-  ActionFailed({@required this.error});
+  @override
+  Widget build(BuildContext context) {
+    return isNullOrEmpty(text)
+        ? Text(
+            text,
+            style: style,
+            textAlign: align,
+          )
+        : Text(
+            placeholderText,
+            style: placeholderStyle,
+            textAlign: placeHolderAlign,
+          );
+  }
 }


### PR DESCRIPTION
**Link to the given issue**
#100 

**Describe what the problem was / what the new feature is**
Added support for creating a setup message (via the settings) and import the created message (clicking on the message within the chat view).

**Additional context**
- Moved identical methods to util classes
- Rewrote our message_item to be better reusable
- Rewrote the validatable_text_form_field to be better reusable
- Optimized the dialog usage
- Optimized our avatar_item to be better reusable

Actual changes are mostly located in the settings_* area.
