### PR TITLE
Provide setting to handle all messages #122 OT-223

### DIFF
--- a/lib/src/l10n/localizations.dart
+++ b/lib/src/l10n/localizations.dart
@@ -522,13 +522,13 @@ class AppLocalizations {
 
   String get chatSettingsChangeMessageSync => Intl.message('Message syncing', name: 'chatSettingsChangeMessageSync');
 
-  String get chatSettingsChangeMessageSyncText => Intl.message('Please choose what kind of messages you would like see.', name: 'chatSettingsChangeMessageSyncText');
+  String get chatSettingsChangeMessageSyncText => Intl.message('Please choose what kind of messages you would like to see.', name: 'chatSettingsChangeMessageSyncText');
 
-  String get chatSettingsChangeMessageSyncOption1 => Intl.message('Only chat', name: 'chatSettingsChangeMessageSyncOption1');
+  String get chatSettingsChangeMessageSyncOption1 => Intl.message('Show only chat messages ', name: 'chatSettingsChangeMessageSyncOption1');
 
-  String get chatSettingsChangeMessageSyncOption2 => Intl.message('My contacts', name: 'chatSettingsChangeMessageSyncOption2');
+  String get chatSettingsChangeMessageSyncOption2 => Intl.message('Show only messages of my contacts', name: 'chatSettingsChangeMessageSyncOption2');
 
-  String get chatSettingsChangeMessageSyncOption3 => Intl.message('Show all', name: 'chatSettingsChangeMessageSyncOption3');
+  String get chatSettingsChangeMessageSyncOption3 => Intl.message('Show all messages, including normal email messages', name: 'chatSettingsChangeMessageSyncOption3');
 
   // Notifications
   String get moreMessages => Intl.message('more messages', name: 'moreMessages');

--- a/lib/src/l10n/localizations.dart
+++ b/lib/src/l10n/localizations.dart
@@ -520,6 +520,16 @@ class AppLocalizations {
 
   String get chatSettingsChangeReadReceiptsText => Intl.message('Enable sending and requesting of read receipts.', name: 'chatSettingsChangeReadReceiptsText');
 
+  String get chatSettingsChangeMessageSync => Intl.message('Message syncing', name: 'chatSettingsChangeMessageSync');
+
+  String get chatSettingsChangeMessageSyncText => Intl.message('Please choose what kind of messages you would like see.', name: 'chatSettingsChangeMessageSyncText');
+
+  String get chatSettingsChangeMessageSyncOption1 => Intl.message('Only chat', name: 'chatSettingsChangeMessageSyncOption1');
+
+  String get chatSettingsChangeMessageSyncOption2 => Intl.message('My contacts', name: 'chatSettingsChangeMessageSyncOption2');
+
+  String get chatSettingsChangeMessageSyncOption3 => Intl.message('Show all', name: 'chatSettingsChangeMessageSyncOption3');
+
   // Notifications
   String get moreMessages => Intl.message('more messages', name: 'moreMessages');
 

--- a/lib/src/settings/settings_chat.dart
+++ b/lib/src/settings/settings_chat.dart
@@ -40,12 +40,12 @@
  * for more details.
  */
 
+import 'package:delta_chat_core/delta_chat_core.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:ox_coi/src/l10n/localizations.dart';
 import 'package:ox_coi/src/settings/settings_chat_bloc.dart';
 import 'package:ox_coi/src/settings/settings_chat_event_state.dart';
-import 'package:ox_coi/src/utils/colors.dart';
 import 'package:ox_coi/src/utils/dimensions.dart';
 import 'package:ox_coi/src/widgets/state_info.dart';
 
@@ -87,34 +87,15 @@ class _SettingsChatState extends State<SettingsChat> {
               ),
               ListTile(
                 contentPadding: EdgeInsets.symmetric(vertical: listItemPadding, horizontal: listItemPaddingBig),
-                title: FractionallySizedBox(
-                  widthFactor: 1,
-                  alignment: Alignment.centerLeft,
-                  child: Text(AppLocalizations.of(context).chatSettingsChangeMessageSync,),
+                title: Text(
+                  AppLocalizations.of(context).chatSettingsChangeMessageSync,
                 ),
-                subtitle: FractionallySizedBox(
-                  widthFactor: 1,
-                  alignment: Alignment.centerLeft,
-                  child: Text(AppLocalizations.of(context).chatSettingsChangeMessageSyncText,),
+                subtitle: Text(
+                  AppLocalizations.of(context).chatSettingsChangeMessageSyncText,
                 ),
-                trailing: DropdownButton(
-                  value: state.inviteSetting,
-                  items: [
-                    DropdownMenuItem(
-                      value: 0,
-                      child: Text(AppLocalizations.of(context).chatSettingsChangeMessageSyncOption1,),
-                    ),
-                    DropdownMenuItem(
-                      value: 1,
-                      child: Text(AppLocalizations.of(context).chatSettingsChangeMessageSyncOption2,),
-                    ),
-                    DropdownMenuItem(
-                      value: 2,
-                      child: Text(AppLocalizations.of(context).chatSettingsChangeMessageSyncOption3,),
-                    )
-                  ],
-                  onChanged: changedDropDownItem
-                ),
+                onTap: () {
+                  _buildMessageSyncChooserDialog(state.inviteSetting);
+                },
               )
             ]).toList(),
           );
@@ -125,11 +106,44 @@ class _SettingsChatState extends State<SettingsChat> {
     );
   }
 
-  void changedDropDownItem(int selectedInviteSetting) {
-    _settingsChatBloc.dispatch((ChangeInviteSetting(newInviteSetting: selectedInviteSetting)));
-  }
-
   void _changeReadReceipts() {
     _settingsChatBloc.dispatch(ChangeReadReceipts());
+  }
+
+  Future<void> _buildMessageSyncChooserDialog(int inviteSetting) async {
+    int selectedInviteSetting = await showDialog<int>(
+        context: context,
+        builder: (BuildContext context) {
+          return SimpleDialog(
+            title: Text(AppLocalizations.of(context).chatSettingsChangeMessageSyncText),
+            children: <Widget>[
+              RadioListTile<int>(
+                title: Text(AppLocalizations.of(context).chatSettingsChangeMessageSyncOption1),
+                value: Context.showEmailsOff,
+                groupValue: inviteSetting,
+                onChanged: _onMessageSyncChooserTab,
+              ),
+              RadioListTile<int>(
+                title: Text(AppLocalizations.of(context).chatSettingsChangeMessageSyncOption2),
+                value: Context.showEmailsAcceptedContacts,
+                groupValue: inviteSetting,
+                onChanged: _onMessageSyncChooserTab,
+              ),
+              RadioListTile<int>(
+                title: Text(AppLocalizations.of(context).chatSettingsChangeMessageSyncOption3),
+                value: Context.showEmailsAll,
+                groupValue: inviteSetting,
+                onChanged: _onMessageSyncChooserTab,
+              ),
+            ],
+          );
+        });
+    if (selectedInviteSetting != null) {
+      _settingsChatBloc.dispatch((ChangeInviteSetting(newInviteSetting: selectedInviteSetting)));
+    }
+  }
+
+  _onMessageSyncChooserTab(int value) {
+    Navigator.pop(context, value);
   }
 }

--- a/lib/src/settings/settings_chat.dart
+++ b/lib/src/settings/settings_chat.dart
@@ -85,6 +85,37 @@ class _SettingsChatState extends State<SettingsChat> {
                 subtitle: Text(AppLocalizations.of(context).chatSettingsChangeReadReceiptsText),
                 trailing: Switch(value: state.readReceiptsEnabled, onChanged: (value) => _changeReadReceipts()),
               ),
+              ListTile(
+                contentPadding: EdgeInsets.symmetric(vertical: listItemPadding, horizontal: listItemPaddingBig),
+                title: FractionallySizedBox(
+                  widthFactor: 1,
+                  alignment: Alignment.centerLeft,
+                  child: Text(AppLocalizations.of(context).chatSettingsChangeMessageSync,),
+                ),
+                subtitle: FractionallySizedBox(
+                  widthFactor: 1,
+                  alignment: Alignment.centerLeft,
+                  child: Text(AppLocalizations.of(context).chatSettingsChangeMessageSyncText,),
+                ),
+                trailing: DropdownButton(
+                  value: state.inviteSetting,
+                  items: [
+                    DropdownMenuItem(
+                      value: 0,
+                      child: Text(AppLocalizations.of(context).chatSettingsChangeMessageSyncOption1,),
+                    ),
+                    DropdownMenuItem(
+                      value: 1,
+                      child: Text(AppLocalizations.of(context).chatSettingsChangeMessageSyncOption2,),
+                    ),
+                    DropdownMenuItem(
+                      value: 2,
+                      child: Text(AppLocalizations.of(context).chatSettingsChangeMessageSyncOption3,),
+                    )
+                  ],
+                  onChanged: changedDropDownItem
+                ),
+              )
             ]).toList(),
           );
         } else {
@@ -92,6 +123,10 @@ class _SettingsChatState extends State<SettingsChat> {
         }
       },
     );
+  }
+
+  void changedDropDownItem(int selectedInviteSetting) {
+    _settingsChatBloc.dispatch((ChangeInviteSetting(newInviteSetting: selectedInviteSetting)));
   }
 
   void _changeReadReceipts() {

--- a/lib/src/settings/settings_chat_bloc.dart
+++ b/lib/src/settings/settings_chat_bloc.dart
@@ -71,19 +71,31 @@ class SettingsChatBloc extends Bloc<SettingsChatEvent, SettingsChatState> {
         yield SettingsChatStateFailure();
       }
     } else if (event is ChatSettingsActionSuccess) {
-      yield SettingsChatStateSuccess(readReceiptsEnabled: event.readReceiptsEnabled);
+      yield SettingsChatStateSuccess(readReceiptsEnabled: event.readReceiptsEnabled, inviteSetting: event.inviteSetting);
+    } else if(event is ChangeInviteSetting){
+      try{
+        _changeInviteSetting(event.newInviteSetting);
+      } catch (error){
+        yield SettingsChatStateFailure();
+      }
     }
   }
 
   void _requestValues() {
     Config config = Config();
-    dispatch(ChatSettingsActionSuccess(readReceiptsEnabled: config.mdnsEnabled == 1));
+    dispatch(ChatSettingsActionSuccess(readReceiptsEnabled: config.mdnsEnabled == 1, inviteSetting: config.showEmails));
   }
 
   void _changeReadReceipts() async {
     Config config = Config();
     int enable = config.mdnsEnabled == 1 ? 0 : 1;
     await config.setValue(Context.configMdnsEnabled, enable);
-    dispatch(ChatSettingsActionSuccess(readReceiptsEnabled: enable == 1));
+    dispatch(ChatSettingsActionSuccess(readReceiptsEnabled: enable == 1, inviteSetting: config.showEmails));
+  }
+
+  void _changeInviteSetting(int newInviteSetting) async {
+    Config config = Config();
+    await config.setValue(Context.configShowEmails, newInviteSetting);
+    dispatch(ChatSettingsActionSuccess(inviteSetting: newInviteSetting, readReceiptsEnabled: config.mdnsEnabled == 1));
   }
 }

--- a/lib/src/settings/settings_chat_bloc.dart
+++ b/lib/src/settings/settings_chat_bloc.dart
@@ -47,10 +47,6 @@ import 'package:delta_chat_core/delta_chat_core.dart';
 import 'package:ox_coi/src/data/config.dart';
 import 'package:ox_coi/src/settings/settings_chat_event_state.dart';
 
-enum SettingsChatType {
-  readReceipts,
-}
-
 class SettingsChatBloc extends Bloc<SettingsChatEvent, SettingsChatState> {
   @override
   SettingsChatState get initialState => SettingsChatStateInitial();
@@ -63,8 +59,7 @@ class SettingsChatBloc extends Bloc<SettingsChatEvent, SettingsChatState> {
       } catch (error) {
         yield SettingsChatStateFailure();
       }
-    }
-    else if (event is ChangeReadReceipts) {
+    } else if (event is ChangeReadReceipts) {
       try {
         _changeReadReceipts();
       } catch (error) {
@@ -72,10 +67,10 @@ class SettingsChatBloc extends Bloc<SettingsChatEvent, SettingsChatState> {
       }
     } else if (event is ChatSettingsActionSuccess) {
       yield SettingsChatStateSuccess(readReceiptsEnabled: event.readReceiptsEnabled, inviteSetting: event.inviteSetting);
-    } else if(event is ChangeInviteSetting){
-      try{
+    } else if (event is ChangeInviteSetting) {
+      try {
         _changeInviteSetting(event.newInviteSetting);
-      } catch (error){
+      } catch (error) {
         yield SettingsChatStateFailure();
       }
     }

--- a/lib/src/settings/settings_chat_event_state.dart
+++ b/lib/src/settings/settings_chat_event_state.dart
@@ -50,14 +50,21 @@ class ChangeReadReceipts extends SettingsChatEvent {}
 
 class ChatSettingsActionSuccess extends SettingsChatEvent {
   bool readReceiptsEnabled;
+  int inviteSetting;
 
-  ChatSettingsActionSuccess({this.readReceiptsEnabled});
+  ChatSettingsActionSuccess({this.readReceiptsEnabled, this.inviteSetting});
 }
 
 class ChatSettingsActionFailed extends SettingsChatEvent {
   final ChatSettingsActionFailed error;
 
   ChatSettingsActionFailed({@required this.error});
+}
+
+class ChangeInviteSetting extends SettingsChatEvent {
+  int newInviteSetting;
+
+  ChangeInviteSetting({@required this.newInviteSetting});
 }
 
 abstract class SettingsChatState {}
@@ -68,8 +75,9 @@ class SettingsChatStateLoading extends SettingsChatState {}
 
 class SettingsChatStateSuccess extends SettingsChatState {
   bool readReceiptsEnabled;
+  int inviteSetting;
 
-  SettingsChatStateSuccess({this.readReceiptsEnabled});
+  SettingsChatStateSuccess({this.readReceiptsEnabled, this.inviteSetting});
 }
 
 class SettingsChatStateFailure extends SettingsChatState {}


### PR DESCRIPTION
**Link to the given issue**
https://github.com/open-xchange/ox-coi/issues/122

**Describe what the problem was / what the new feature is**
It was not possible to change the config to get invites from all emails, accepted contacts or only chats.

**Describe your solution**
Added another settings option in the ChatSettingsScreen to select an Option from a DropDown Menu.