### PR TITLE
Move invite view to the chat list #58 OT-163

### DIFF
--- a/lib/src/chat/chat_change_bloc.dart
+++ b/lib/src/chat/chat_change_bloc.dart
@@ -45,7 +45,6 @@ import 'dart:async';
 import 'package:bloc/bloc.dart';
 import 'package:delta_chat_core/delta_chat_core.dart';
 import 'package:ox_coi/src/chat/chat_change_event_state.dart';
-import 'package:ox_coi/src/data/chat_message_repository.dart';
 import 'package:ox_coi/src/data/contact_repository.dart';
 import 'package:ox_coi/src/data/repository.dart';
 import 'package:ox_coi/src/data/repository_manager.dart';
@@ -86,7 +85,7 @@ class ChatChangeBloc extends Bloc<ChatChangeEvent, ChatChangeState> {
     Context context = Context();
     var chatId;
     if (contactId != null) {
-      Repository<ChatMsg> inviteMessageRepository = RepositoryManager.get(RepositoryType.chatMessage, ChatMessageRepository.inviteChatId);
+      Repository<ChatMsg> inviteMessageRepository = RepositoryManager.get(RepositoryType.chatMessage, Chat.typeInvite);
       inviteMessageRepository.clear();
       chatId = await context.createChatByContactId(contactId);
     } else if (messageId != null) {

--- a/lib/src/chat/chat_create.dart
+++ b/lib/src/chat/chat_create.dart
@@ -102,7 +102,7 @@ class _ChatCreateState extends State<ChatCreate> {
   }
 
   Widget onBuildResultOrSuggestion(String query) {
-    _contactListBloc.dispatch(FilterContacts(query: query));
+    _contactListBloc.dispatch(SearchContacts(query: query));
     return buildList(false);
   }
 

--- a/lib/src/chat/chat_create_group_participants.dart
+++ b/lib/src/chat/chat_create_group_participants.dart
@@ -112,7 +112,7 @@ class _ChatCreateGroupParticipantsState extends State<ChatCreateGroupParticipant
   }
 
   Widget onBuildResultOrSuggestion(String query) {
-    _contactListBloc.dispatch(FilterContacts(query: query));
+    _contactListBloc.dispatch(SearchContacts(query: query));
     return buildList();
   }
 

--- a/lib/src/chat/chat_create_mixin.dart
+++ b/lib/src/chat/chat_create_mixin.dart
@@ -81,7 +81,7 @@ mixin CreateChatMixin {
       } else {
         navigation.pushAndRemoveUntil(
           context,
-          MaterialPageRoute(builder: (context) => Chat(state.chatId)),
+          MaterialPageRoute(builder: (context) => Chat(chatId: state.chatId)),
           ModalRoute.withName(Navigation.root),
           Navigatable(Type.chatList),
         );

--- a/lib/src/chat/chat_profile.dart
+++ b/lib/src/chat/chat_profile.dart
@@ -40,6 +40,7 @@
  * for more details.
  */
 
+import 'package:delta_chat_core/delta_chat_core.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:ox_coi/src/chat/chat_bloc.dart';
@@ -48,15 +49,17 @@ import 'package:ox_coi/src/chat/chat_profile_group.dart';
 import 'package:ox_coi/src/chat/chat_profile_single.dart';
 import 'package:ox_coi/src/contact/contact_list_bloc.dart';
 import 'package:ox_coi/src/contact/contact_list_event_state.dart';
+import 'package:ox_coi/src/data/contact_repository.dart';
 import 'package:ox_coi/src/l10n/localizations.dart';
 import 'package:ox_coi/src/navigation/navigatable.dart';
 import 'package:ox_coi/src/navigation/navigation.dart';
 import 'package:ox_coi/src/utils/widgets.dart';
 
 class ChatProfile extends StatefulWidget {
-  final int _chatId;
+  final int chatId;
+  final int messageId;
 
-  ChatProfile(this._chatId);
+  ChatProfile({@required this.chatId, this.messageId});
 
   @override
   _ChatProfileState createState() => _ChatProfileState();
@@ -71,8 +74,14 @@ class _ChatProfileState extends State<ChatProfile> {
   void initState() {
     super.initState();
     navigation.current = Navigatable(Type.chatProfile);
-    _chatBloc.dispatch(RequestChat(widget._chatId));
-    _contactListBloc.dispatch(RequestContacts(listTypeOrChatId: widget._chatId));
+    _chatBloc.dispatch(RequestChat(chatId: widget.chatId, messageId: widget.messageId));
+    int listTypeOrChatId;
+    if (widget.chatId == Chat.typeInvite) {
+      listTypeOrChatId = ContactRepository.inviteContacts;
+    } else {
+      listTypeOrChatId = widget.chatId;
+    }
+    _contactListBloc.dispatch(RequestContacts(listTypeOrChatId: listTypeOrChatId));
   }
 
   @override
@@ -95,7 +104,7 @@ class _ChatProfileState extends State<ChatProfile> {
                 if (state is ChatStateSuccess) {
                   bool _isVerified = state.isVerified;
                   if (state.isGroupChat) {
-                    return ChatProfileGroup(widget._chatId, state.name, state.color, _isVerified);
+                    return ChatProfileGroup(widget.chatId, state.name, state.color, _isVerified);
                   } else {
                     return _buildChatProfileOneToOne(state);
                   }
@@ -113,7 +122,7 @@ class _ChatProfileState extends State<ChatProfile> {
         builder: (context, state) {
           if (state is ContactListStateSuccess) {
             var key = createKeyString(state.contactIds.first, state.contactLastUpdateValues.first);
-            return ChatProfileOneToOne(widget._chatId, _isSelfTalk, state.contactIds.first, key);
+            return ChatProfileOneToOne(widget.chatId, _isSelfTalk, state.contactIds.first, key);
           } else {
             return Container();
           }

--- a/lib/src/chat/chat_profile_single.dart
+++ b/lib/src/chat/chat_profile_single.dart
@@ -40,6 +40,7 @@
  * for more details.
  */
 
+import 'package:delta_chat_core/delta_chat_core.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:ox_coi/src/chat/chat_change_bloc.dart';
@@ -78,8 +79,16 @@ class _ChatProfileOneToOneState extends State<ChatProfileOneToOne> with ContactP
   @override
   void initState() {
     super.initState();
-    _contactItemBloc.dispatch(RequestContact(contactId: widget._contactId, listType: ContactRepository.validContacts));
+    var listType;
+    if (isInvite()) {
+      listType = ContactRepository.inviteContacts;
+    } else {
+      listType = ContactRepository.validContacts;
+    }
+    _contactItemBloc.dispatch(RequestContact(contactId: widget._contactId, listType: listType));
   }
+
+  bool isInvite() => widget._chatId == Chat.typeInvite;
 
   @override
   void dispose() {
@@ -125,16 +134,17 @@ class _ChatProfileOneToOneState extends State<ChatProfileOneToOne> with ContactP
               ),
               onTap: () => _showBlockContactDialog(ChatProfileViewAction.block),
             ),
-          ListTile(
-            leading: Icon(
-              Icons.delete,
-              color: accent,
+          if (!isInvite())
+            ListTile(
+              leading: Icon(
+                Icons.delete,
+                color: accent,
+              ),
+              title: Text(
+                AppLocalizations.of(context).chatProfileDeleteChatButtonText,
+              ),
+              onTap: () => _showBlockContactDialog(ChatProfileViewAction.delete),
             ),
-            title: Text(
-              AppLocalizations.of(context).chatProfileDeleteChatButtonText,
-            ),
-            onTap: () => _showBlockContactDialog(ChatProfileViewAction.delete),
-          ),
         ]),
       ],
     );
@@ -177,7 +187,7 @@ class _ChatProfileOneToOneState extends State<ChatProfileOneToOne> with ContactP
 
   _blockContact() {
     ContactChangeBloc contactChangeBloc = ContactChangeBloc();
-    contactChangeBloc.dispatch(BlockContact(widget._contactId, widget._chatId));
+    contactChangeBloc.dispatch(BlockContact(contactId: widget._contactId, chatId: widget._chatId));
     navigation.popUntil(context, ModalRoute.withName(Navigation.root));
   }
 

--- a/lib/src/chatlist/chat_list_event_state.dart
+++ b/lib/src/chatlist/chat_list_event_state.dart
@@ -42,21 +42,40 @@
 
 import 'package:meta/meta.dart';
 
+import 'chat_list_bloc.dart';
+
 abstract class ChatListEvent {}
 
 class RequestChatList extends ChatListEvent {
-  String query;
+  final bool showInvites;
 
-  RequestChatList({this.query});
+  RequestChatList({@required this.showInvites});
 }
 
-class ChatListModified extends ChatListEvent {}
+class SearchChatList extends ChatListEvent {
+  final String query;
+  final bool showInvites;
 
-class ChatListSearched extends ChatListEvent {
+  SearchChatList({@required this.query, @required this.showInvites});
+}
+
+class InvitesPrepared extends ChatListEvent {
+  final String query;
+  final List<int> messageIds;
+
+  InvitesPrepared({this.query, @required this.messageIds});
+}
+
+class ChatsPrepared extends ChatListEvent {
   final List<int> chatIds;
-  final List<int> lastUpdateValues;
 
-  ChatListSearched({@required this.chatIds, @required this.lastUpdateValues});
+  ChatsPrepared({@required this.chatIds});
+}
+
+class ChatListModified extends ChatListEvent {
+  final ChatListItemWrapper chatListItemWrapper;
+
+  ChatListModified({@required this.chatListItemWrapper});
 }
 
 abstract class ChatListState {}
@@ -66,12 +85,10 @@ class ChatListStateInitial extends ChatListState {}
 class ChatListStateLoading extends ChatListState {}
 
 class ChatListStateSuccess extends ChatListState {
-  final List<int> chatIds;
-  final List<int> chatLastUpdateValues;
+  final ChatListItemWrapper chatListItemWrapper;
 
   ChatListStateSuccess({
-    @required this.chatIds,
-    @required this.chatLastUpdateValues,
+    @required this.chatListItemWrapper,
   });
 }
 
@@ -79,4 +96,12 @@ class ChatListStateFailure extends ChatListState {
   final String error;
 
   ChatListStateFailure({@required this.error});
+}
+
+class ChatListItemWrapper {
+  final List<int> ids;
+  final List<ChatListItemType> types;
+  final List<int> lastUpdateValues;
+
+  ChatListItemWrapper({@required this.ids, @required this.types, @required this.lastUpdateValues});
 }

--- a/lib/src/chatlist/chat_list_item.dart
+++ b/lib/src/chatlist/chat_list_item.dart
@@ -70,7 +70,7 @@ class _ChatListItemState extends State<ChatListItem> {
   @override
   void initState() {
     super.initState();
-    _chatBloc.dispatch(RequestChat(widget._chatId));
+    _chatBloc.dispatch(RequestChat(chatId: widget._chatId));
     _isSelected = false;
   }
 
@@ -106,10 +106,11 @@ class _ChatListItemState extends State<ChatListItem> {
             freshMessageCount: freshMessageCount,
             timestamp: timestamp,
             subTitleIcon: _chatBloc.isGroup
-              ? Icon(
-              Icons.group,
-              size: iconSize,
-            ) : Container(),
+                ? Icon(
+                    Icons.group,
+                    size: iconSize,
+                  )
+                : Container(),
             onTap: chatItemTapped,
           ),
         );
@@ -118,23 +119,25 @@ class _ChatListItemState extends State<ChatListItem> {
   }
 
   chatItemTapped(String name, String subtitle) {
-    if(widget._isMultiSelect) {
+    if (widget._isMultiSelect) {
       setState(() {
         _isSelected = _isSelected ? false : true;
       });
       widget._onTap(widget._chatId);
-    }else if(widget._isShareItem) {
+    } else if (widget._isShareItem) {
       widget._onTap(widget._chatId);
-    }else{
+    } else {
       navigation.push(
         context,
-        MaterialPageRoute(builder: (context) => Chat(widget._chatId),),
+        MaterialPageRoute(
+          builder: (context) => Chat(chatId: widget._chatId),
+        ),
       );
     }
   }
 
-  chatItemLongPress(){
-    if(!widget._isMultiSelect) {
+  chatItemLongPress() {
+    if (!widget._isMultiSelect) {
       setState(() {
         _isSelected = _isSelected ? false : true;
       });

--- a/lib/src/chatlist/chat_list_parent.dart
+++ b/lib/src/chatlist/chat_list_parent.dart
@@ -40,6 +40,7 @@
  * for more details.
  */
 
+import 'package:delta_chat_core/delta_chat_core.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:ox_coi/src/chat/chat_change_bloc.dart';
@@ -47,7 +48,7 @@ import 'package:ox_coi/src/chat/chat_change_event_state.dart';
 import 'package:ox_coi/src/chatlist/chat_list.dart';
 import 'package:ox_coi/src/chatlist/chat_list_bloc.dart';
 import 'package:ox_coi/src/chatlist/chat_list_event_state.dart';
-import 'package:ox_coi/src/chatlist/invite_list.dart';
+import 'package:ox_coi/src/data/chat_message_repository.dart';
 import 'package:ox_coi/src/l10n/localizations.dart';
 import 'package:ox_coi/src/main/root_child.dart';
 import 'package:ox_coi/src/message/message_list_bloc.dart';
@@ -70,7 +71,7 @@ class ChatListParent extends RootChild {
   @override
   _ChatListViewState createState() {
     final state = _ChatListViewState();
-    setActions([state.getSearchAction()]);
+    //setActions([state.getSearchAction()]);
     return state;
   }
 
@@ -125,7 +126,7 @@ class _ChatListViewState extends State<ChatListParent> with SingleTickerProvider
   @override
   void initState() {
     super.initState();
-    _messagesBloc.dispatch(RequestMessages(1));
+    _messagesBloc.dispatch(RequestMessages(chatId: Chat.typeInvite));
     controller = TabController(length: 2, vsync: this);
     _isMultiSelect = false;
     _selectedChats = List();
@@ -190,8 +191,8 @@ class _ChatListViewState extends State<ChatListParent> with SingleTickerProvider
           child: TabBarView(
             controller: controller,
             children: <Widget>[
-              ChatList(_switchMultiSelect, _itemTapped, _isMultiSelect),
-              InviteList(),
+              /*ChatList(_switchMultiSelect, _itemTapped, _isMultiSelect),
+              InviteList(),*/
             ],
           ),
         )
@@ -247,7 +248,7 @@ class _ChatListViewState extends State<ChatListParent> with SingleTickerProvider
     _switchMultiSelect(null);
   }
 
-  Widget getSearchAction() {
+/*Widget getSearchAction() {
     Search search = Search(
       onBuildResults: onBuildResultOrSuggestion,
       onBuildSuggestion: onBuildResultOrSuggestion,
@@ -296,6 +297,6 @@ class _ChatListViewState extends State<ChatListParent> with SingleTickerProvider
         return ChatListItem(chatId, null, null, false, false, key);
       },
     );
-  }
+  }*/
 
 }

--- a/lib/src/chatlist/invite_item.dart
+++ b/lib/src/chatlist/invite_item.dart
@@ -42,16 +42,14 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:ox_coi/src/chat/chat.dart';
 import 'package:ox_coi/src/chat/chat_create_mixin.dart';
 import 'package:ox_coi/src/contact/contact_change_bloc.dart';
 import 'package:ox_coi/src/contact/contact_change_event_state.dart';
-import 'package:ox_coi/src/l10n/localizations.dart';
 import 'package:ox_coi/src/message/message_item_bloc.dart';
 import 'package:ox_coi/src/message/message_item_event_state.dart';
-import 'package:ox_coi/src/navigation/navigatable.dart';
 import 'package:ox_coi/src/navigation/navigation.dart';
 import 'package:ox_coi/src/utils/colors.dart';
-import 'package:ox_coi/src/utils/dialog_builder.dart';
 import 'package:ox_coi/src/widgets/avatar_list_item.dart';
 
 class InviteItem extends StatefulWidget {
@@ -81,30 +79,43 @@ class _InviteItemState extends State<InviteItem> with CreateChatMixin {
       bloc: _messageItemBloc,
       builder: (context, state) {
         String name;
-        String subTitle;
+        String preview;
         Color color;
+        int timestamp = 0;
         if (state is MessageItemStateSuccess) {
           var contactWrapper = state.contactWrapper;
           _contactId = contactWrapper.contactId;
           name = contactWrapper.contactAddress;
-          subTitle = state.messageText;
+          preview = state.preview;
+          timestamp = state.messageTimestamp;
           color = avatarDefaultBackground;
         } else {
           name = "";
-          subTitle = "";
+          preview = "";
         }
         return AvatarListItem(
           title: name,
-          subTitle: subTitle,
+          subTitle: preview,
           color: color,
+          timestamp: timestamp,
           onTap: inviteItemTapped,
+          isInvite: true,
         );
       },
     );
   }
 
   inviteItemTapped(String name, String message) {
-    return showNavigatableDialog(
+    navigation.push(
+      context,
+      MaterialPageRoute(
+        builder: (context) => Chat(
+              chatId: widget._chatId,
+              messageId: widget._messageId,
+            ),
+      ),
+    );
+    /*return showNavigatableDialog(
       context: context,
       navigatable: Navigatable(Type.contactInviteDialog),
       dialog: AlertDialog(
@@ -133,12 +144,12 @@ class _InviteItemState extends State<InviteItem> with CreateChatMixin {
           ),
         ],
       ),
-    );
+    );*/
   }
 
   void blockUser() {
     ContactChangeBloc contactChangeBloc = ContactChangeBloc();
-    contactChangeBloc.dispatch(BlockContact(_contactId, null));
+    contactChangeBloc.dispatch(BlockContact(contactId: _contactId, chatId: widget._chatId));
   }
 
   @override

--- a/lib/src/chatlist/invite_list.dart
+++ b/lib/src/chatlist/invite_list.dart
@@ -40,6 +40,7 @@
  * for more details.
  */
  
+import 'package:delta_chat_core/delta_chat_core.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:ox_coi/src/chatlist/invite_item.dart';
@@ -64,7 +65,7 @@ class _InviteListState extends State<InviteList> {
     super.initState();
     var navigation = Navigation();
     navigation.current = Navigatable(Type.inviteList);
-    _messagesBloc.dispatch(RequestMessages(1));
+    _messagesBloc.dispatch(RequestMessages(chatId: Chat.typeInvite));
   }
 
   @override

--- a/lib/src/contact/contact_change.dart
+++ b/lib/src/contact/contact_change.dart
@@ -123,7 +123,7 @@ class _ContactChangeState extends State<ContactChange> {
           chatRepository.putIfAbsent(id: chatId);
           navigation.pushAndRemoveUntil(
             context,
-            MaterialPageRoute(builder: (context) => Chat(chatId)),
+            MaterialPageRoute(builder: (context) => Chat(chatId: chatId)),
             ModalRoute.withName(Navigation.root),
             Navigatable(Type.contactList),
           );

--- a/lib/src/contact/contact_change_event_state.dart
+++ b/lib/src/contact/contact_change_event_state.dart
@@ -72,10 +72,11 @@ class ContactDeleted extends ContactChangeEvent {}
 class ContactDeleteFailed extends ContactChangeEvent {}
 
 class BlockContact extends ContactChangeEvent {
-  final int id;
+  final int contactId;
   final int chatId;
+  final int messageId;
 
-  BlockContact(this.id, this.chatId);
+  BlockContact({@required this.chatId, this.contactId, this.messageId});
 }
 
 class ContactBlocked extends ContactChangeEvent {}

--- a/lib/src/contact/contact_details.dart
+++ b/lib/src/contact/contact_details.dart
@@ -69,7 +69,6 @@ class ContactDetailsView extends StatelessWidget with ContactProfileMixin, Creat
   final int _contactId;
 
   ContactDetailsView(this._contactId) {
-    print("[ContactDetailsView.ContactDetailsView] dboehrs - BLAA!");
     _navigation.current = Navigatable(Type.contactProfile);
     _contactItemBloc.dispatch(RequestContact(contactId: _contactId, listType: ContactRepository.validContacts));
   }

--- a/lib/src/contact/contact_item.dart
+++ b/lib/src/contact/contact_item.dart
@@ -115,7 +115,7 @@ class _ContactItemState extends State<ContactItem> with ContactItemBuilder, Crea
     } else {
       navigation.pushAndRemoveUntil(
         context,
-        MaterialPageRoute(builder: (context) => Chat(chatId)),
+        MaterialPageRoute(builder: (context) => Chat(chatId: chatId)),
         ModalRoute.withName(Navigation.root),
         Navigatable(Type.chatList),
       );

--- a/lib/src/contact/contact_list.dart
+++ b/lib/src/contact/contact_list.dart
@@ -193,7 +193,7 @@ class _ContactListState extends State<ContactListView> {
   }
 
   Widget onBuildResultOrSuggestion(String query) {
-    _contactListBloc.dispatch(FilterContacts(query: query));
+    _contactListBloc.dispatch(SearchContacts(query: query));
     return buildList();
   }
 

--- a/lib/src/contact/contact_list_event_state.dart
+++ b/lib/src/contact/contact_list_event_state.dart
@@ -60,17 +60,17 @@ class ContactsSelectionChanged extends ContactListEvent {
 
 class BlockedContactsChanged extends ContactListEvent {}
 
-class FilterContacts extends ContactListEvent {
+class SearchContacts extends ContactListEvent {
   final String query;
 
-  FilterContacts({@required this.query});
+  SearchContacts({@required this.query});
 }
 
-class ContactsFiltered extends ContactListEvent {
+class ContactsSearched extends ContactListEvent {
   final List<int> ids;
   final List<int> lastUpdates;
 
-  ContactsFiltered({@required this.ids, @required this.lastUpdates});
+  ContactsSearched({@required this.ids, @required this.lastUpdates});
 }
 
 abstract class ContactListState {}

--- a/lib/src/data/chat_message_repository.dart
+++ b/lib/src/data/chat_message_repository.dart
@@ -45,8 +45,6 @@ import 'package:ox_coi/src/data/repository.dart';
 
 class ChatMessageRepository extends Repository<ChatMsg> {
 
-  static const inviteChatId = 1;
-
   ChatMessageRepository(RepositoryItemCreator<ChatMsg> creator) : super(creator);
 
   @override

--- a/lib/src/invite/invite_mixin.dart
+++ b/lib/src/invite/invite_mixin.dart
@@ -40,62 +40,18 @@
  * for more details.
  */
 
-import 'dart:ui';
+import 'package:delta_chat_core/delta_chat_core.dart';
+import 'package:ox_coi/src/data/repository.dart';
+import 'package:ox_coi/src/data/repository_manager.dart';
 
-import 'package:meta/meta.dart';
+mixin InviteMixin {
+  bool isInviteChat(int chatId) => chatId == Chat.typeInvite;
 
-abstract class ChatEvent {}
+  bool isInvite(int chatId, int messageId) => isInviteChat(chatId) && messageId != null && messageId != 0;
 
-class RequestChat extends ChatEvent {
-  final int chatId;
-  final int messageId;
-
-  RequestChat({@required this.chatId, this.messageId});
-}
-
-class ChatLoaded extends ChatEvent {
-  final String name;
-  final String subTitle;
-  final Color color;
-  final int freshMessageCount;
-  final bool isSelfTalk;
-  final bool isGroupChat;
-  final String preview;
-  final int timestamp;
-  final bool isVerified;
-
-  ChatLoaded(this.name, this.subTitle, this.color, this.freshMessageCount, this.isSelfTalk, this.isGroupChat, this.preview, this.timestamp, this.isVerified);
-}
-
-abstract class ChatState {}
-
-class ChatStateInitial extends ChatState {}
-
-class ChatStateLoading extends ChatState {}
-
-class ChatStateSuccess extends ChatState {
-  final String name;
-  final String subTitle;
-  final Color color;
-  final int freshMessageCount;
-  final bool isSelfTalk;
-  final bool isGroupChat;
-  final String preview;
-  final int timestamp;
-  final bool isVerified;
-
-  ChatStateSuccess(
-    {@required this.name,
-      @required this.subTitle,
-      @required this.color,
-      @required this.freshMessageCount,
-      @required this.isSelfTalk,
-      @required this.isGroupChat,
-      @required this.preview,
-      @required this.timestamp,
-      @required this.isVerified});
-}
-
-class ChatStateFailure extends ChatState {
-  ChatStateFailure({@required error});
+  Future<int> getContactIdFromMessage(int messageId) async {
+    Repository<ChatMsg> messageListRepository = RepositoryManager.get(RepositoryType.chatMessage, Chat.typeInvite);
+    ChatMsg message = messageListRepository.get(messageId);
+    return await message.getFromId();
+  }
 }

--- a/lib/src/l10n/localizations.dart
+++ b/lib/src/l10n/localizations.dart
@@ -315,6 +315,8 @@ class AppLocalizations {
 
   String get chatEmpty => Intl.message('This is a new chat. Send a message to connect!', name: 'chatEmpty');
 
+  String get chatInviteQuestion => Intl.message('Do you want to chat with this new contact?', name: 'chatInviteQuestion');
+
 
   // Chat profile view
   String get chatProfileBlockContactInfoText => Intl.message('Do you want to block the contact?', name: 'chatProfileBlockContactInfoText');

--- a/lib/src/main/root.dart
+++ b/lib/src/main/root.dart
@@ -41,7 +41,7 @@
  */
 
 import 'package:flutter/material.dart';
-import 'package:ox_coi/src/chatlist/chat_list_parent.dart';
+import 'package:ox_coi/src/chatlist/chat_list.dart';
 import 'package:ox_coi/src/contact/contact_list.dart';
 import 'package:ox_coi/src/main/root_child.dart';
 import 'package:ox_coi/src/user/user_profile.dart';
@@ -57,7 +57,7 @@ class _RootState extends State<Root> {
   var childList = List<RootChild>();
 
   _RootState() {
-    childList.addAll([new ChatListParent(this), new ContactListView(this), new UserProfileView(this)]);
+    childList.addAll([new ChatList(this), new ContactListView(this), new UserProfileView(this)]);
   }
 
   @override

--- a/lib/src/message/message_item_bloc.dart
+++ b/lib/src/message/message_item_bloc.dart
@@ -76,7 +76,7 @@ class MessageItemBloc extends Bloc<MessageItemEvent, MessageItemState> {
         _messageId = event.messageId;
         _addContact = event.isGroupChat || isInvite(chatId);
         if (_addContact) {
-          _setupContact();
+          await _setupContact();
         }
         _setupMessage();
         dispatch(MessageLoaded());
@@ -93,6 +93,7 @@ class MessageItemBloc extends Bloc<MessageItemEvent, MessageItemState> {
       int timestamp = await message.getTimestamp();
       int state = await message.getState();
       int showPadlock = await message.showPadlock();
+      String teaser = await message.getSummaryText(200);
       AttachmentWrapper attachmentWrapper;
       if (hasFile) {
         attachmentWrapper = AttachmentWrapper(
@@ -117,38 +118,26 @@ class MessageItemBloc extends Bloc<MessageItemEvent, MessageItemState> {
           contactAddress: contactAddress,
           contactColor: contactColor,
         );
-        yield MessageItemStateSuccess(
-          messageIsOutgoing: isOutgoing,
-          messageText: text,
-          hasFile: hasFile,
-          isSetupMessage: isSetupMessage,
-          isInfo: isInfo,
-          messageTimestamp: timestamp,
-          state: state,
-          showPadlock: showPadlock,
-          attachmentWrapper: attachmentWrapper,
-          contactWrapper: contactWrapper,
-        );
-      } else {
-        yield MessageItemStateSuccess(
-          messageIsOutgoing: isOutgoing,
-          messageText: text,
-          hasFile: hasFile,
-          isSetupMessage: isSetupMessage,
-          isInfo: isInfo,
-          messageTimestamp: timestamp,
-          state: state,
-          showPadlock: showPadlock,
-          attachmentWrapper: attachmentWrapper,
-          contactWrapper: contactWrapper,
-        );
       }
+      yield MessageItemStateSuccess(
+        messageIsOutgoing: isOutgoing,
+        messageText: text,
+        hasFile: hasFile,
+        isSetupMessage: isSetupMessage,
+        isInfo: isInfo,
+        messageTimestamp: timestamp,
+        state: state,
+        showPadlock: showPadlock,
+        attachmentWrapper: attachmentWrapper,
+        contactWrapper: contactWrapper,
+        preview: teaser,
+      );
     }
   }
 
   bool isInvite(int chatId) => chatId == Chat.typeInvite;
 
-  void _setupContact() async {
+  Future<void> _setupContact() async {
     ChatMsg message = _getMessage();
     _contactId = await message.getFromId();
     if (isInvite(await message.getChatId())) {

--- a/lib/src/message/message_item_event_state.dart
+++ b/lib/src/message/message_item_event_state.dart
@@ -73,6 +73,7 @@ class MessageItemStateSuccess extends MessageItemState {
   final int showPadlock;
   final ContactWrapper contactWrapper;
   final AttachmentWrapper attachmentWrapper;
+  final String preview;
 
   MessageItemStateSuccess({
     @required this.messageText,
@@ -85,6 +86,7 @@ class MessageItemStateSuccess extends MessageItemState {
     @required this.showPadlock,
     @required this.attachmentWrapper,
     @required this.contactWrapper,
+    @required this.preview,
   });
 }
 

--- a/lib/src/message/message_list_event_state.dart
+++ b/lib/src/message/message_list_event_state.dart
@@ -45,17 +45,28 @@ import 'package:meta/meta.dart';
 abstract class MessageListEvent {}
 
 class RequestMessages extends MessageListEvent {
-  int chatId;
+  final int chatId;
+  final int messageId;
 
-  RequestMessages(this.chatId);
+  RequestMessages({@required this.chatId, this.messageId});
 }
 
 class UpdateMessages extends MessageListEvent {}
 
 class MessagesLoaded extends MessageListEvent {
-  List<int> dateMarkerIds;
+  final List<int> messageIds;
+  final List<int> messageLastUpdateValues;
+  final List<int> dateMarkerIds;
 
-  MessagesLoaded({this.dateMarkerIds});
+  MessagesLoaded({@required this.messageIds, @required this.messageLastUpdateValues, this.dateMarkerIds});
+}
+
+class SendMessage extends MessageListEvent {
+  final String text;
+  final String path;
+  final int fileType;
+
+  SendMessage({this.text, this.path, this.fileType});
 }
 
 abstract class MessageListState {}

--- a/lib/src/notifications/local_push_manager.dart
+++ b/lib/src/notifications/local_push_manager.dart
@@ -83,8 +83,8 @@ class LocalPushManager {
     List<int> createdNotifications = List();
     List<int> freshMessages = await getAndFilterFreshMessages();
     Future.forEach(freshMessages, (int messageId) async {
-      ChatMsg chatMessage = _temporaryMessageRepository.get(messageId);
-      int chatId = await chatMessage.getChatId();
+      ChatMsg message = _temporaryMessageRepository.get(messageId);
+      int chatId = await message.getChatId();
       if (!createdNotifications.contains(chatId)) {
         createdNotifications.add(chatId);
         String title = await _chatRepository.get(chatId).getName();
@@ -92,8 +92,8 @@ class LocalPushManager {
         if (count > 1) {
           title = "$title (+ $count ${AppLocalizations.of(_buildContext).moreMessages})";
         }
-        String teaser = await chatMessage.getSummaryText(200);
-        showNotificationIfRequired(chatId, title, teaser);
+        String preview = await message.getSummaryText(200);
+        showNotificationIfRequired(chatId, title, preview);
       }
     });
   }

--- a/lib/src/notifications/notification_manager.dart
+++ b/lib/src/notifications/notification_manager.dart
@@ -96,7 +96,7 @@ class NotificationManager{
     Navigation navigation = Navigation();
     navigation.push(
       _buildContext,
-      MaterialPageRoute(builder: (context) => Chat(int.parse(payload))),
+      MaterialPageRoute(builder: (context) => Chat(chatId: int.parse(payload))),
     );
   }
 

--- a/lib/src/qr/scan_qr.dart
+++ b/lib/src/qr/scan_qr.dart
@@ -76,7 +76,7 @@ class _ScanQrState extends State<ScanQr> {
           _progressOverlayEntry.remove();
           _navigation.pushAndRemoveUntil(
             context,
-            MaterialPageRoute(builder: (context) => Chat(state.chatId)),
+            MaterialPageRoute(builder: (context) => Chat(chatId: state.chatId)),
             ModalRoute.withName(Navigation.root),
             Navigatable(Type.chat)
           );

--- a/lib/src/share/share.dart
+++ b/lib/src/share/share.dart
@@ -137,7 +137,7 @@ class _ShareScreenState extends State<ShareScreen> {
     _shareBloc.dispatch(ForwardMessages(chatId, widget._msgIds));
     navigation.pushAndRemoveUntil(
       context,
-      MaterialPageRoute(builder: (context) => Chat(chatId)),
+      MaterialPageRoute(builder: (context) => Chat(chatId: chatId)),
       ModalRoute.withName(Navigation.root),
       Navigatable(Type.chat, params: [chatId]),
     );

--- a/lib/src/share/share_bloc.dart
+++ b/lib/src/share/share_bloc.dart
@@ -96,14 +96,14 @@ class ShareBloc extends Bloc<ShareEvent, ShareState>{
     chatListObservable.listen((state) {
       if (state is ChatListStateSuccess) {
         _completeList.clear();
-        _chatIds = state.chatIds;
-        if(state.chatIds != null){
-          _completeList.insertAll(0, state.chatIds);
+        _chatIds = state.chatListItemWrapper.ids;
+        if(_chatIds != null){
+          _completeList.insertAll(0, _chatIds);
         }
         _contactListBloc.dispatch(RequestContacts(listTypeOrChatId: ContactRepository.validContacts));
       }
     });
-    _chatListBloc.dispatch(RequestChatList());
+    _chatListBloc.dispatch(RequestChatList(showInvites: false));
   }
 
   void forwardMessages(int destinationChatId, List<int> messageIds) async{

--- a/lib/src/utils/colors.dart
+++ b/lib/src/utils/colors.dart
@@ -76,6 +76,9 @@ const Color textInverted = Colors.white;
 
 // Icons / images
 const Color appBarIcon = Colors.white;
+const Color textColorInverted = Colors.white;
+const Color divider = Colors.black;
+final Color error = Colors.red[800];
 
 // Progress
 final Color progressBackground = Colors.black45;

--- a/lib/src/widgets/avatar_list_item.dart
+++ b/lib/src/widgets/avatar_list_item.dart
@@ -60,20 +60,22 @@ class AvatarListItem extends StatelessWidget {
   final IconData avatarIcon;
   final int timestamp;
   final bool isVerified;
+  final bool isInvite;
 
-  AvatarListItem(
-      {@required this.title,
-      @required this.subTitle,
-      @required this.onTap,
-      this.avatarIcon,
-      this.imagePath,
-      this.color,
-      this.freshMessageCount = 0,
-      this.titleIcon,
-      this.subTitleIcon,
-      this.timestamp = 0,
-      this.isVerified = false,
-      });
+  AvatarListItem({
+    @required this.title,
+    @required this.subTitle,
+    @required this.onTap,
+    this.avatarIcon,
+    this.imagePath,
+    this.color,
+    this.freshMessageCount = 0,
+    this.titleIcon,
+    this.subTitleIcon,
+    this.timestamp = 0,
+    this.isVerified = false,
+    this.isInvite = false,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -89,81 +91,89 @@ class AvatarListItem extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: <Widget>[
             avatarIcon == null
-              ? Avatar(
-                  imagePath: imagePath,
-                  textPrimary: title,
-                  textSecondary: subTitle,
-                  color: color,
-                )
-              : CircleAvatar(
-                  radius: listAvatarRadius,
-                  foregroundColor: avatarForegroundColor,
-                  child: Icon(avatarIcon),
-                ),
+                ? Avatar(
+                    imagePath: imagePath,
+                    textPrimary: title,
+                    textSecondary: subTitle,
+                    color: color,
+                  )
+                : CircleAvatar(
+                    radius: listAvatarRadius,
+                    foregroundColor: avatarForegroundColor,
+                    child: Icon(avatarIcon),
+                  ),
             Expanded(
               child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.stretch,
-                  children: <Widget>[
-                    Row(
-                      children: <Widget>[
-                        Padding(
-                          padding: const EdgeInsets.only(right: iconTextPadding),
-                          child: titleIcon != null ? titleIcon : Container(),
-                        ),
-                        Expanded(
-                          child: getTitle()
-                        ),
-                        Visibility(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: <Widget>[
+                  Row(
+                    children: <Widget>[
+                      Padding(
+                        padding: const EdgeInsets.only(right: iconTextPadding),
+                        child: titleIcon != null ? titleIcon : Container(),
+                      ),
+                      Expanded(child: getTitle()),
+                      Visibility(
                           visible: timestamp != null && timestamp != 0,
                           child: Text(
                             getChatListTime(AppLocalizations.of(context), timestamp),
                             style: TextStyle(
-                              color: freshMessageCount != null && freshMessageCount > 0 ? Colors.black : Colors.grey,
-                              fontWeight: freshMessageCount != null && freshMessageCount > 0 ? FontWeight.bold : FontWeight.normal,
-                              fontSize: 14.0
-                            ),
-                          )
-                        ),
-                      ],
-                    ),
-                    Padding(
+                                color: shouldHighlight() ? Colors.black : Colors.grey,
+                                fontWeight: shouldHighlight() ? FontWeight.bold : FontWeight.normal,
+                                fontSize: 14.0),
+                          )),
+                    ],
+                  ),
+                  Padding(
                       padding: EdgeInsets.symmetric(
-                        vertical: listItemPaddingSmall,
-                      )
-                    ),
-                    Row(
-                      children: <Widget>[
-                        Padding(
+                    vertical: listItemPaddingSmall,
+                  )),
+                  Row(
+                    children: <Widget>[
+                      Padding(
+                        padding: const EdgeInsets.only(right: iconTextPadding),
+                        child: subTitleIcon != null ? subTitleIcon : Container(),
+                      ),
+                      Visibility(
+                        visible: isVerified,
+                        child: Padding(
                           padding: const EdgeInsets.only(right: iconTextPadding),
-                          child: subTitleIcon != null ? subTitleIcon : Container(),
-                        ),
-                        Visibility(
-                          visible: isVerified,
-                          child: Padding(
-                            padding: const EdgeInsets.only(right: iconTextPadding),
-                            child: Icon(
-                              Icons.verified_user,
-                              size: iconSize,
-                            ),
+                          child: Icon(
+                            Icons.verified_user,
+                            size: iconSize,
                           ),
                         ),
-                        Expanded(child: getSubTitle()),
-                        Visibility(
-                          visible: freshMessageCount != null && freshMessageCount > 0,
-                          child: Container(
-                            padding: EdgeInsets.only(left: 8.0, right: 8.0, top: 4.0, bottom: 4.0),
-                            decoration: BoxDecoration(color: primary, borderRadius: BorderRadius.circular(100)),
-                            child: Text(
-                              freshMessageCount <= 99 ? freshMessageCount.toString() : "99+",
-                              style: TextStyle(color: Colors.white, fontSize: 12.0),
-                            ),
+                      ),
+                      Expanded(child: getSubTitle()),
+                      Visibility(
+                        visible: isInvite,
+                        child: Container(
+                          width: 23.0,
+                          padding: EdgeInsets.only(left: 8.0, right: 8.0, top: 4.0, bottom: 4.0),
+                          decoration: BoxDecoration(color: Colors.orangeAccent, borderRadius: BorderRadius.circular(16)),
+                          child: Text(
+                            "!",
+                            style: TextStyle(color: Colors.white, fontSize: 12.0, fontWeight: FontWeight.bold),
+                            textAlign: TextAlign.center,
                           ),
                         ),
-                      ],
-                    ),
-                    Divider(),
-                  ],
-                ),
+                      ),
+                      Visibility(
+                        visible: hasNewMessages(),
+                        child: Container(
+                          padding: EdgeInsets.only(left: 8.0, right: 8.0, top: 4.0, bottom: 4.0),
+                          decoration: BoxDecoration(color: primary, borderRadius: BorderRadius.circular(16)),
+                          child: Text(
+                            freshMessageCount <= 99 ? freshMessageCount.toString() : "99+",
+                            style: TextStyle(color: Colors.white, fontSize: 12.0),
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                  Divider(),
+                ],
+              ),
             ),
           ],
         ),
@@ -171,28 +181,29 @@ class AvatarListItem extends StatelessWidget {
     );
   }
 
+  bool hasNewMessages() => freshMessageCount != null && freshMessageCount > 0;
+
+  bool shouldHighlight() => isInvite || (freshMessageCount != null && freshMessageCount > 0);
+
   StatelessWidget getTitle() {
     return Visibility(
-      visible: title != null,
-      child: Text(
-        title != null ? title : "",
-        maxLines: 1,
-        overflow: TextOverflow.ellipsis,
-        style: chatItemTitle,
-      )
-    );
+        visible: title != null,
+        child: Text(
+          title != null ? title : "",
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: chatItemTitle,
+        ));
   }
 
   StatelessWidget getSubTitle() {
     return Visibility(
-      visible: subTitle != null,
-      child: Text(
-        subTitle != null ? subTitle :"",
-        maxLines: 1,
-        overflow: TextOverflow.ellipsis,
-        style: TextStyle(color: textLessImportant),
-      )
-    );
+        visible: subTitle != null,
+        child: Text(
+          subTitle != null ? subTitle : "",
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: TextStyle(color: textLessImportant),
+        ));
   }
-
 }


### PR DESCRIPTION
**Link to the given issue**
#58

**Describe what the problem was / what the new feature is**
Invites are now displayed in the chat list, not in an extra view.

**Describe your solution**

- Altered the chat list to be able to display invite items
- Extended the chat list bloc to be able to merge chats and invites
- Extended the chat view to allow "invite chats" (extra UI added)
- Extended the single chat profile view, to also work with "invite chats"
- Removed ChatMessageRepository.inviteChatId as we already have Chat.typeInvite
- Added InviteMixin to avoid duplicated code (while implementing #129 we should apply InviteMixin to more classes)
- Smaller cleanups
- Smaller renamings

**Additional context**
- I kept the invite list and the chat list parent as #129 will need some parts of the code. Everything not needed should be removed while implementing #129 
