### PR TITLE
Disable text suggestions in server setup fields #138

### DIFF
--- a/lib/src/login/login_manual_settings.dart
+++ b/lib/src/login/login_manual_settings.dart
@@ -91,7 +91,10 @@ class _ManualSettingsState extends State<ManualSettings> {
     validationHint: (context) => AppLocalizations.of(context).validatableTextFormFieldHintInvalidPassword,
   );
   ValidatableTextFormField imapLoginNameField = ValidatableTextFormField((context) => AppLocalizations.of(context).loginLabelImapName);
-  ValidatableTextFormField imapServerField = ValidatableTextFormField((context) => AppLocalizations.of(context).loginLabelImapServer);
+  ValidatableTextFormField imapServerField = ValidatableTextFormField(
+      (context) => AppLocalizations.of(context).loginLabelImapServer,
+    inputType: TextInputType.url,
+  );
   ValidatableTextFormField imapPortField = ValidatableTextFormField(
       (context) => AppLocalizations.of(context).loginLabelImapPort,
     textFormType: TextFormType.port,
@@ -106,7 +109,10 @@ class _ManualSettingsState extends State<ManualSettings> {
     needValidation: true,
     validationHint: (context) => AppLocalizations.of(context).validatableTextFormFieldHintInvalidPassword,
   );
-  ValidatableTextFormField smtpServerField = ValidatableTextFormField((context) => AppLocalizations.of(context).loginLabelSmtpServer);
+  ValidatableTextFormField smtpServerField = ValidatableTextFormField(
+      (context) => AppLocalizations.of(context).loginLabelSmtpServer,
+    inputType: TextInputType.url,
+  );
   ValidatableTextFormField smtpPortField = ValidatableTextFormField(
       (context) => AppLocalizations.of(context).loginLabelSmtpPort,
     textFormType: TextFormType.port,

--- a/lib/src/login/login_provider_list.dart
+++ b/lib/src/login/login_provider_list.dart
@@ -45,6 +45,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:ox_coi/src/l10n/localizations.dart';
 import 'package:ox_coi/src/login/providers.dart';
+import 'package:ox_coi/src/navigation/navigatable.dart';
 import 'package:ox_coi/src/navigation/navigation.dart';
 import 'package:ox_coi/src/utils/dimensions.dart';
 import 'package:ox_coi/src/utils/styles.dart';
@@ -69,6 +70,8 @@ class _ProviderListState extends State<ProviderList> {
   @override
   void initState() {
     super.initState();
+    var navigation = Navigation();
+    navigation.current = Navigatable(Type.loginProviderList);
     _loginBloc.dispatch(RequestProviders());
   }
 

--- a/lib/src/login/login_provider_signin.dart
+++ b/lib/src/login/login_provider_signin.dart
@@ -98,7 +98,7 @@ class _ProviderSignInState extends State<ProviderSignIn> {
   @override
   void initState() {
     super.initState();
-    _navigation.current = Navigatable(Type.loginManualSettings);
+    _navigation.current = Navigatable(Type.loginProviderSignIn);
     final loginObservable = new Observable<LoginState>(_loginBloc.state);
     loginObservable.listen((state) => handleLoginStateChange(state));
   }

--- a/lib/src/widgets/validatable_text_form_field.dart
+++ b/lib/src/widgets/validatable_text_form_field.dart
@@ -90,6 +90,7 @@ class _ValidatableTextFormFieldState extends State<ValidatableTextFormField> {
         controller: widget.controller,
         keyboardType: widget.inputType,
         enabled: widget.enabled,
+        autocorrect: false,
         validator: (value) => _validate(value),
         decoration: _getInputDecoration());
   }


### PR DESCRIPTION
**Link to the given issue**
https://github.com/open-xchange/ox-coi/issues/138

**Describe what the problem was / what the new feature is**
- After adding a dot in the SMTP or IMAP server field, a space is added
- Sometimes entered text is exchange, e.g. "smtp" is tranferred to "SMTP"
- Upper and lowercase is sometimes guessed

**Describe your solution**
Disabled autocorrect for the ValidatableTextFormField. And set the inputType for the server adresses to TextInputType.url

**Additional context**
Fixed wrong or missing navigation.current