### PR TITLE
OT-258 build 32 bit also for debug

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -46,6 +46,11 @@ android {
     }
 
     buildTypes {
+        debug {
+            ndk {
+                abiFilters "armeabi-v7a"
+            }
+        }
         release {
             // TODO: Add your own signing config for the release build.
             // Signing with the debug keys for now, so `flutter run --release` works.


### PR DESCRIPTION
We have to enforce 32 bit for now, even for debug builds, otherwise the CI builds will fail on some devices.
