### PR TITLE
OT-128 Enhance chat message view #28

### DIFF
--- a/lib/src/message/message_item.dart
+++ b/lib/src/message/message_item.dart
@@ -134,7 +134,7 @@ class _ChatMessageItemState extends State<ChatMessageItem> with AutomaticKeepAli
             children: buildMessageAndMarker(state),
           );
         } else {
-          return StateInfo(showLoading: true);
+          return Container();
         }
       },
     );

--- a/lib/src/message/message_item_bloc.dart
+++ b/lib/src/message/message_item_bloc.dart
@@ -64,7 +64,6 @@ class MessageItemBloc extends Bloc<MessageItemEvent, MessageItemState> {
   @override
   Stream<MessageItemState> mapEventToState(MessageItemState currentState, MessageItemEvent event) async* {
     if (event is RequestMessage) {
-      yield MessageItemStateLoading();
       try {
         var chatId = event.chatId;
         if (isInvite(chatId)) {

--- a/lib/src/message/message_list_bloc.dart
+++ b/lib/src/message/message_list_bloc.dart
@@ -130,7 +130,7 @@ class MessageListBloc extends Bloc<MessageListEvent, MessageListState> with Invi
     _messageListRepository.putIfAbsent(ids: messageIds);
     await Future.forEach(messageIds, (id) async {
       ChatMsg message = _messageListRepository.get(id);
-      if (await message.isOutgoing()) {
+      if (await message.isOutgoing() && await message.getState() != ChatMsg.messageStateReceived) {
         await message.reloadValue(ChatMsg.methodMessageGetState);
       }
     });


### PR DESCRIPTION
**Link to the given issue**
#28

**Describe what the problem was / what the new feature is**

- We are already doing paged loading, as we only load messages relevant for the view port. The flickering after receiving or sending a message is based on a Flutter framework bug (see https://github.com/flutter/flutter/issues/21023), as all elements which change their index are recreated, even if matching objects (for given identical keys) could be used. We have to wait until the framework bug is fixed
- Removing the reverse logic would lead to huge problems when scrolling the view (on start, on new message, on compose and so on). Doing this manually would be problematic and error prone

**Changes:**

- Removed the loading spinner for messages
- Removed the loading state for messages
- Tried to reduce redraw of outgoing messages
 
