### PR TITLE
OT-333 Register: do not show Other mail provider option

### DIFF
--- a/lib/src/login/login.dart
+++ b/lib/src/login/login.dart
@@ -114,6 +114,7 @@ class _LoginState extends State<Login> {
         children: <Widget>[
           Text(
             L10n.get(L.welcome),
+            textAlign: TextAlign.center,
             style: Theme.of(context).textTheme.headline,
           ),
           Image(
@@ -158,6 +159,7 @@ class _LoginState extends State<Login> {
                   style: Theme.of(context).textTheme.caption.apply(color: onBackground),
                   text: L10n.get(L.agreeTo),
                   children: [
+                    TextSpan(text: " "),
                     UrlTextSpan(url: null, text: L10n.get(L.termsConditions)),
                     TextSpan(text: " ${L10n.get(L.and)} "),
                     UrlTextSpan(url: null, text: L10n.get(L.privacyDeclaration))

--- a/lib/src/login/login_provider_list.dart
+++ b/lib/src/login/login_provider_list.dart
@@ -131,20 +131,21 @@ class _ProviderListState extends State<ProviderList> {
                 },
               ),
             ),
-            Padding(
-              padding: EdgeInsets.only(top: loginVerticalPadding24dp),
-              child: RaisedButton(
-                elevation: 0,
-                onPressed: () => _onItemTap(otherProvider),
-                child: Text(L10n.get(L.providerOtherMailProvider)),
-                textColor: accent,
-                color: background,
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(loginOtherProviderButtonRadius),
-                  side: BorderSide(color: accent),
+            if (widget.type == ProviderListType.login)
+              Padding(
+                padding: EdgeInsets.only(top: loginVerticalPadding24dp),
+                child: RaisedButton(
+                  elevation: 0,
+                  onPressed: () => _onItemTap(otherProvider),
+                  child: Text(L10n.get(L.providerOtherMailProvider)),
+                  textColor: accent,
+                  color: background,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(loginOtherProviderButtonRadius),
+                    side: BorderSide(color: accent),
+                  ),
                 ),
               ),
-            ),
           ],
         ));
   }


### PR DESCRIPTION
**Link to the given issue**
https://jira.open-xchange.com/browse/OT-333

**Describe what the problem was / what the new feature is**

- Added a check to get the current context and only show the other provider button if the login context is active
- Also centered the welcome text
- Added a white space in the bottom text
