### PR TITLE
OT-421 Hide "Enable background updates"

### DIFF
--- a/lib/src/l10n/l.dart
+++ b/lib/src/l10n/l.dart
@@ -319,6 +319,8 @@ class L {
   static final settingNotificationP = _translationKey("Notification", "Notifications");
   static final settingNotificationPull = _translationKey("Enable background updates");
   static final settingNotificationPullText = _translationKey("If enabled, this setting allows the app to perform periodic background tasks to get new messages");
+  static final settingNotificationPush = _translationKey("Change Push Settings");
+  static final settingNotificationPushText = _translationKey("Change the push settings in your app settings.");
   static final settingAboutBugReports = _translationKey("Bug reports");
   // "GitHub" is an own name. Please don't translate it
   static final settingAboutBugReportsText = _translationKey("Please report bugs on GitHub.");

--- a/lib/src/settings/settings_notifications.dart
+++ b/lib/src/settings/settings_notifications.dart
@@ -40,6 +40,7 @@
  * for more details.
  */
 
+import 'package:app_settings/app_settings.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:ox_coi/src/l10n/l.dart';
@@ -86,12 +87,25 @@ class _SettingsNotificationsState extends State<SettingsNotifications> {
         } else if (state is SettingsNotificationsStateSuccess) {
           return ListView(
             children: ListTile.divideTiles(context: context, tiles: [
-              ListTile(
-                contentPadding: EdgeInsets.symmetric(vertical: listItemPadding, horizontal: listItemPaddingBig),
-                title: Text(L10n.get(L.settingNotificationPull)),
-                subtitle: Text(L10n.get(L.settingNotificationPullText)),
-                trailing: Switch(value: state.pullActive, onChanged: (value) => _changeNotificationsSetting()),
+              Visibility(
+                visible: !state.coiSupported,
+                child: ListTile(
+                  contentPadding: EdgeInsets.symmetric(vertical: listItemPadding, horizontal: listItemPaddingBig),
+                  title: Text(L10n.get(L.settingNotificationPull)),
+                  subtitle: Text(L10n.get(L.settingNotificationPullText)),
+                  trailing: Switch(value: state.pullActive, onChanged: (value) => _changeNotificationsSetting()),
+                ),
               ),
+              Visibility(
+                visible: state.coiSupported,
+                child: ListTile(
+                  contentPadding: EdgeInsets.symmetric(vertical: listItemPadding, horizontal: listItemPaddingBig),
+                  title: Text(L10n.get(L.settingNotificationPush)),
+                  subtitle: Text(L10n.get(L.settingNotificationPushText)),
+                  trailing: Icon(Icons.arrow_forward),
+                  onTap: ()=> {AppSettings.openAppSettings()},
+                ),
+              )
             ]).toList(),
           );
         } else {
@@ -106,5 +120,4 @@ class _SettingsNotificationsState extends State<SettingsNotifications> {
   _changeNotificationsSetting() {
     _settingsNotificationsBloc.dispatch(ChangeSetting());
   }
-
 }

--- a/lib/src/settings/settings_notifications_bloc.dart
+++ b/lib/src/settings/settings_notifications_bloc.dart
@@ -59,9 +59,9 @@ class SettingsNotificationsBloc extends Bloc<SettingsNotificationsEvent, Setting
         yield SettingsNotificationsStateFailure();
       }
     } else if (event is SettingLoaded) {
-      yield SettingsNotificationsStateSuccess(pullActive: event.pullActive);
+      yield SettingsNotificationsStateSuccess(pullActive: event.pullActive, coiSupported: event.isCoiSupported);
     } else if (event is ActionSuccess) {
-      yield SettingsNotificationsStateSuccess(pullActive: event.pullActive);
+      yield SettingsNotificationsStateSuccess(pullActive: event.pullActive, coiSupported: false);
     } else if (event is ChangeSetting) {
       changeSettings();
     }
@@ -69,12 +69,13 @@ class SettingsNotificationsBloc extends Bloc<SettingsNotificationsEvent, Setting
 
   void loadSettings() async {
     bool pullPreference = await getPreference(preferenceNotificationsPull);
+    bool isSupportedCoi = await isCoiSupported();
     if (pullPreference == null) {
-      bool defaultPullPreference = !(await isCoiSupported());
+      bool defaultPullPreference = !isSupportedCoi;
       await setPreference(preferenceNotificationsPull, defaultPullPreference);
       pullPreference = defaultPullPreference;
     }
-    dispatch(SettingLoaded(pullActive: pullPreference));
+    dispatch(SettingLoaded(pullActive: pullPreference, isCoiSupported: isSupportedCoi));
   }
 
   void changeSettings() async {

--- a/lib/src/settings/settings_notifications_event_state.dart
+++ b/lib/src/settings/settings_notifications_event_state.dart
@@ -48,8 +48,9 @@ class RequestSetting extends SettingsNotificationsEvent {}
 
 class SettingLoaded extends SettingsNotificationsEvent {
   final bool pullActive;
+  final bool isCoiSupported;
 
-  SettingLoaded({@required this.pullActive});
+  SettingLoaded({@required this.pullActive, @required this.isCoiSupported});
 }
 
 class ChangeSetting extends SettingsNotificationsEvent {}
@@ -66,8 +67,9 @@ class SettingsNotificationsStateInitial extends SettingsNotificationsState {}
 
 class SettingsNotificationsStateSuccess extends SettingsNotificationsState {
   final bool pullActive;
+  final bool coiSupported;
 
-  SettingsNotificationsStateSuccess({@required this.pullActive});
+  SettingsNotificationsStateSuccess({@required this.pullActive, @required this.coiSupported});
 }
 
 class SettingsNotificationsStateFailure extends SettingsNotificationsState {}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,6 +11,7 @@ dependencies:
     sdk: flutter
   flutter_localizations:
     sdk: flutter
+  app_settings: 1.0.6+2
   background_fetch: ^0.2.0
   bloc: ^0.14.4
   contacts_service: ^0.2.8


### PR DESCRIPTION
**Link to the given issue**
[Internal Bug Tracker](https://jira.open-xchange.com/browse/OT-421)

**Describe what the problem was / what the new feature is**
The "Enable background updates" option was displayed in the settings, even if we have a coi server.

**Describe your solution**
Added another option when we have a coi-server that leads to the app settings.
