### PR TITLE
OT-448 Sharing a file to own app is not possible

### DIFF
--- a/android/app/src/main/java/com/openxchange/oxcoi/MainActivity.java
+++ b/android/app/src/main/java/com/openxchange/oxcoi/MainActivity.java
@@ -145,7 +145,7 @@ public class MainActivity extends FlutterActivity {
                 String text = intent.getStringExtra(Intent.EXTRA_TEXT);
                 ShareHelper shareHelper = new ShareHelper();
                 String uriPath = shareHelper.getFilePathForUri(this, uri);
-                if(!text.isEmpty()){
+                if(text != null && !text.isEmpty()){
                     sharedData.put(SHARED_TEXT, text);
                 }
                 sharedData.put(SHARED_MIME_TYPE, type);

--- a/lib/src/chat/chat.dart
+++ b/lib/src/chat/chat.dart
@@ -151,6 +151,12 @@ class _ChatState extends State<Chat> with ChatComposer, ChatCreateMixin, InviteM
         });
       } else {
         setFileData();
+        if(widget.sharedData.text.isNotEmpty){
+          _textController.text = widget.sharedData.text;
+          setState(() {
+            _isComposingText = true;
+          });
+        }
       }
     }
   }

--- a/lib/src/message/message_item.dart
+++ b/lib/src/message/message_item.dart
@@ -88,6 +88,7 @@ class _ChatMessageItemState extends State<ChatMessageItem> with AutomaticKeepAli
     const MessageAction(title: 'Copy', icon: Icons.content_copy, messageActionTag: MessageActionTag.copy),
     const MessageAction(title: 'Delete locally', icon: Icons.delete, messageActionTag: MessageActionTag.delete),
     const MessageAction(title: 'Flag/Unflag', icon: Icons.star, messageActionTag: MessageActionTag.flag),
+    const MessageAction(title: 'Share', icon: Icons.share, messageActionTag: MessageActionTag.share),
   ];
 
   final List<MessageAction> _messageAttachmentActions = const <MessageAction>[

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,7 +20,6 @@ dependencies:
   date_format: ^1.0.6
   device_info: ^0.4.0+2
   downloads_path_provider: ^0.1.0
-  esys_flutter_share: ^1.0.2
   firebase_messaging: 5.1.4
   file_picker: ^1.3.8
   flutter_bloc: ^0.20.0


### PR DESCRIPTION
**Link to the given issue**
[Internal Bug Tracker](https://jira.open-xchange.com/browse/OT-448)

**Describe what the problem was / what the new feature is**
Sharing a file from our app with our app ended in empty messages.

**Describe your solution**
Removed the sharing library. The app handles the intent for sharing files itself.

**Additional context**
The option to send files with text is not active but possible.