### PR TITLE
HOTFIX: adds support for bottom safe area

### DIFF
--- a/lib/src/chat/chat.dart
+++ b/lib/src/chat/chat.dart
@@ -284,7 +284,7 @@ class _ChatState extends State<Chat> with ChatComposer, ChatCreateMixin, InviteM
               if (state is ChatStateSuccess && !state.isRemoved)
                 new Container(
                   decoration: new BoxDecoration(color: Theme.of(context).cardColor),
-                  child: _buildTextComposer(),
+                  child: SafeArea(child: _buildTextComposer()),
                 ),
             ],
           ),


### PR DESCRIPTION
**Describe what the problem was / what the new feature is**
On devices with rounded corner displays there are so called safe areas. When composing a chat message, the bottom bar containing the text field should take note for this (bottom) safe area.
