### PR TITLE
OT-454 Autocrypt setup is not sorted correctly into chat list

### DIFF
--- a/lib/src/chatlist/chat_list_bloc.dart
+++ b/lib/src/chatlist/chat_list_bloc.dart
@@ -251,7 +251,7 @@ class ChatListBloc extends Bloc<ChatListEvent, ChatListState> {
         chatSummaries.putIfAbsent(chatId, () => chatSummary);
       }
       await chatList.tearDown();
-      _chatRepository.putIfAbsent(ids: chatIds);
+      _chatRepository.update(ids: chatIds);
       chatSummaries.forEach((id, chatSummary) {
         var summary = _chatRepository.get(id).get(ChatExtension.chatSummary);
         if(summary != chatSummary) {

--- a/lib/src/login/login_bloc.dart
+++ b/lib/src/login/login_bloc.dart
@@ -159,9 +159,11 @@ class LoginBloc extends Bloc<LoginEvent, LoginState> {
   }
 
   void _unregisterListeners() {
-    _core.removeListener(Event.configureProgress, _loginSubject);
-    _core.removeListener(Event.error, _errorSubject);
-    _listenersRegistered = false;
+    if (_listenersRegistered) {
+      _core.removeListener(Event.configureProgress, _loginSubject);
+      _core.removeListener(Event.error, _errorSubject);
+      _listenersRegistered = false;
+    }
   }
 
   bool _loginSuccess(int progress) {

--- a/lib/src/notifications/local_push_manager.dart
+++ b/lib/src/notifications/local_push_manager.dart
@@ -76,8 +76,10 @@ class LocalPushManager {
   }
 
   Future<void> tearDown() async {
-    _core.removeListener(Event.incomingMsg, _messageSubject);
-    _listenersRegistered = false;
+    if (_listenersRegistered) {
+      _core.removeListener(Event.incomingMsg, _messageSubject);
+      _listenersRegistered = false;
+    }
   }
 
   void _successCallback(Event event) {

--- a/lib/src/push/push_bloc.dart
+++ b/lib/src/push/push_bloc.dart
@@ -282,10 +282,12 @@ class PushBloc extends Bloc<PushEvent, PushState> {
   }
 
   void _unregisterListeners() {
-    _core.removeListener(Event.setMetaDataDone, pushSubject);
-    _core.removeListener(Event.webPushSubscription, pushSubject);
-    _core.removeListener(Event.error, pushSubject);
-    _listenersRegistered = false;
+    if (_listenersRegistered) {
+      _core.removeListener(Event.setMetaDataDone, pushSubject);
+      _core.removeListener(Event.webPushSubscription, pushSubject);
+      _core.removeListener(Event.error, pushSubject);
+      _listenersRegistered = false;
+    }
   }
 
   void _metadataSuccessCallback(Event event) {

--- a/lib/src/qr/qr_bloc.dart
+++ b/lib/src/qr/qr_bloc.dart
@@ -134,10 +134,12 @@ class QrBloc extends Bloc<QrEvent, QrState> {
   }
 
   void _unregisterListeners() {
-    _core.removeListener(Event.secureJoinInviterProgress, _qrSubject);
-    _core.removeListener(Event.secureJoinJoinerProgress, _qrSubject);
-    _core.removeListener(Event.error, _errorSubject);
-    _listenersRegistered = false;
+    if (_listenersRegistered) {
+      _core.removeListener(Event.secureJoinInviterProgress, _qrSubject);
+      _core.removeListener(Event.secureJoinJoinerProgress, _qrSubject);
+      _core.removeListener(Event.error, _errorSubject);
+      _listenersRegistered = false;
+    }
   }
 
   void getQrText(int chatId) async {

--- a/lib/src/settings/settings_security_bloc.dart
+++ b/lib/src/settings/settings_security_bloc.dart
@@ -134,8 +134,10 @@ class SettingsSecurityBloc extends Bloc<SettingsSecurityEvent, SettingsSecurityS
   }
 
   void _unregisterListeners() {
-    _core.removeListener(Event.imexProgress, _keyActionSubject);
-    _listenersRegistered = false;
+    if (_listenersRegistered) {
+      _core.removeListener(Event.imexProgress, _keyActionSubject);
+      _listenersRegistered = false;
+    }
   }
 
   _successCallback(Event event) {


### PR DESCRIPTION
**Link to the given issue**
[Internal bug tracker](https://jira.open-xchange.com/browse/OT-454)

**Describe what the problem was / what the new feature is**
We had a general problem with updating the chat list order if the list wasn't open.

**Describe your solution**
Now updating the values, instead of just adding them if missing. This reorders the list and fixes the problem.

**Additional context**
- Added some guards for listener deregistration
- Please also see the related pull request in the plugin: https://github.com/open-xchange/flutter-deltachat-core/pull/52
