### PR TITLE
OT-490 #242 Verified icon not shown

### DIFF
--- a/lib/src/qr/qr_bloc.dart
+++ b/lib/src/qr/qr_bloc.dart
@@ -176,10 +176,18 @@ class QrBloc extends Bloc<QrEvent, QrState> {
     } else {
       Repository<Chat> chatRepository = RepositoryManager.get(RepositoryType.chat);
       chatRepository.putIfAbsent(id: chatId);
-      var contactRepository = RepositoryManager.get(RepositoryType.contact);
-      var contacts = await context.getChatContacts(chatId);
-      contactRepository.putIfAbsent(ids: contacts);
+      await createOrUpdateContact(context, chatId);
       add(JoinDone(chatId: chatId));
+    }
+  }
+
+  Future createOrUpdateContact(Context context, int chatId) async {
+    var contactRepository = RepositoryManager.get(RepositoryType.contact);
+    var contactIdList = await context.getChatContacts(chatId);
+    var contactId = contactIdList?.first;
+    if (contactId != null) {
+      contactRepository.putIfAbsent(id: contactId);
+      contactRepository.get(contactId).reloadValue(Contact.methodContactIsVerified);
     }
   }
 


### PR DESCRIPTION
**Link to the given issue**
#242

**Describe what the problem was / what the new feature is**
The user who started the verification didn't saw the verified icon of the other user until a restart of the app was performed.

**Describe your solution**
The verified state of our cached contact entry is now reloaded after a successful verify. As this was missing the repository wasn't updated, so a restart was needed.

**Additional context**
Also added a null check, even though the contactId shouldn't be ever null.
