### PR TITLE
OT-414 Mobile-number is available after deleting and reimporting

### DIFF
--- a/lib/src/contact/contact_import_bloc.dart
+++ b/lib/src/contact/contact_import_bloc.dart
@@ -196,13 +196,18 @@ class ContactImportBloc extends Bloc<ContactImportEvent, ContactImportState> {
       var contact = _contactRepository.get(contactId);
       var mail = await contact.getAddress();
       var contactPhoneNumbers = phoneNumbers[mail];
+      var contactExtension = await contactExtensionProvider.getContactExtension(contactId: contactId);
       if (contactPhoneNumbers != null && contactPhoneNumbers.isNotEmpty) {
-        var contactExtension = await contactExtensionProvider.getContactExtension(contactId: contactId);
         if (contactExtension == null) {
           contactExtension = ContactExtension(contactId, phoneNumbers: contactPhoneNumbers);
           contactExtensionProvider.insert(contactExtension);
         } else {
           contactExtension.phoneNumbers = contactPhoneNumbers;
+          contactExtensionProvider.update(contactExtension);
+        }
+      } else {
+        if(contactExtension != null){
+          contactExtension.phoneNumbers = "";
           contactExtensionProvider.update(contactExtension);
         }
       }


### PR DESCRIPTION
**Link to the given issue**
[Internal Bug Tracker](https://jira.open-xchange.com/browse/OT-414?src=confmacro)

**Describe what the problem was / what the new feature is**
Mobile-number is available after deleting and reimporting. The contact extension was not updated correctly.

**Describe your solution**
Updated the contact extension correctly.