### PR TITLE
Issue-255 Visualize send errors OT-502

### DIFF
--- a/lib/src/adaptiveWidgets/adaptive_icon.dart
+++ b/lib/src/adaptiveWidgets/adaptive_icon.dart
@@ -100,6 +100,8 @@ enum IconSource {
   forward,
   share,
   play,
+  pending,
+  retry,
 }
 
 class AdaptiveIcon extends AdaptiveWidget<Icon, Icon> {
@@ -182,6 +184,8 @@ class AdaptiveIcon extends AdaptiveWidget<Icon, Icon> {
     IconSource.forward : [CupertinoIcons.forward, Icons.forward],
     IconSource.share : [CupertinoIcons.share, Icons.share],
     IconSource.play : [CupertinoIcons.play_arrow_solid, Icons.play_arrow],
+    IconSource.pending : [Icons.hourglass_empty, Icons.hourglass_empty],
+    IconSource.retry : [Icons.autorenew, Icons.autorenew],
   };
 
   AdaptiveIcon({

--- a/lib/src/chat/chat_profile_group_contact_item.dart
+++ b/lib/src/chat/chat_profile_group_contact_item.dart
@@ -48,6 +48,8 @@ import 'package:ox_coi/src/contact/contact_item_bloc.dart';
 import 'package:ox_coi/src/contact/contact_item_builder_mixin.dart';
 import 'package:ox_coi/src/contact/contact_item_event_state.dart';
 import 'package:ox_coi/src/data/contact_repository.dart';
+import 'package:ox_coi/src/l10n/l.dart';
+import 'package:ox_coi/src/l10n/l10n.dart';
 import 'package:ox_coi/src/navigation/navigatable.dart';
 import 'package:ox_coi/src/navigation/navigation.dart';
 
@@ -150,14 +152,14 @@ class _ChatProfileGroupContactItemState extends State<ChatProfileGroupContactIte
 }
 
 List<GroupPopupMenu> participantChoices = <GroupPopupMenu>[
-  GroupPopupMenu(title: 'Info', action: GroupParticipantActions.info),
-  GroupPopupMenu(title: 'Send message', action: GroupParticipantActions.sendMessage),
-  GroupPopupMenu(title: 'Remove from group', action: GroupParticipantActions.remove),
+  GroupPopupMenu(title: L10n.get(L.groupParticipantActionInfo), action: GroupParticipantActions.info),
+  GroupPopupMenu(title: L10n.get(L.groupParticipantActionSendMessage), action: GroupParticipantActions.sendMessage),
+  GroupPopupMenu(title: L10n.get(L.groupParticipantActionRemove), action: GroupParticipantActions.remove),
 ];
 
 List<GroupPopupMenu> meChoices = <GroupPopupMenu>[
-  GroupPopupMenu(title: 'Info', action: GroupParticipantActions.info),
-  GroupPopupMenu(title: 'Send message', action: GroupParticipantActions.sendMessage),
+  GroupPopupMenu(title: L10n.get(L.groupParticipantActionInfo), action: GroupParticipantActions.info),
+  GroupPopupMenu(title: L10n.get(L.groupParticipantActionSendMessage), action: GroupParticipantActions.sendMessage),
 ];
 
 class GroupPopupMenu {

--- a/lib/src/l10n/l.dart
+++ b/lib/src/l10n/l.dart
@@ -224,6 +224,9 @@ class L {
   static final groupRename = _translationKey("Rename group");
   static final groupNameLabel = _translationKey("Set a group name");
   static final groupAddContactAdd = _translationKey("Simply add one by tapping on a contact.");
+  static final groupParticipantActionInfo = _translationKey("Info");
+  static final groupParticipantActionSendMessage = _translationKey("Send message");
+  static final groupParticipantActionRemove = _translationKey("Remove from group");
 
   static final loginRunning = _translationKey("Logging in, this may take a moment");
   static final loginFailed = _translationKey("Login failed");
@@ -246,6 +249,15 @@ class L {
   static final memberXP = _translationKey("1 member","%i members");
   static final memberAdded = _translationKey("Member added");
   static final memberRemoved = _translationKey("Member removed");
+
+  static final messageActionForward = _translationKey("Forward");
+  static final messageActionCopy = _translationKey("Copy");
+  static final messageActionDelete = _translationKey("Delete locally");
+  static final messageActionFlagUnflag = _translationKey("Flag/Unflag");
+  static final messageActionShare = _translationKey("Share");
+  static final messageActionInfo = _translationKey("Info");
+  static final messageActionRetry = _translationKey("Send again");
+  static final messageActionDeleteFailedMessage = _translationKey("Discard message");
 
   static final participantXP = _translationKey("1 participant", "%i participants");
   static final participantAdd = _translationKey("Add participants");

--- a/lib/src/message/message_action.dart
+++ b/lib/src/message/message_action.dart
@@ -42,7 +42,7 @@
 
 import 'package:ox_coi/src/adaptiveWidgets/adaptive_icon.dart';
 
-enum MessageActionTag { forward, copy, delete, flag, share }
+enum MessageActionTag { forward, copy, delete, flag, share, retry, info }
 
 class MessageAction {
   final String title;

--- a/lib/src/message/message_builder.dart
+++ b/lib/src/message/message_builder.dart
@@ -444,14 +444,33 @@ class MessagePartState extends StatelessWidget {
       builder: (context, state) {
         if (state is MessageItemStateSuccess) {
           var messageState = state.messageStateData.state;
-          if (messageState == ChatMsg.messageStateDelivered || messageState == ChatMsg.messageStateReceived) {
-            IconSource icon = messageState == ChatMsg.messageStateDelivered ? IconSource.done : IconSource.doneAll;
+          if (messageState == ChatMsg.messageStateDelivered || messageState == ChatMsg.messageStateReceived || messageState == ChatMsg.messageStatePending || messageState == ChatMsg.messageStateFailed) {
+            IconSource icon;
+            Color color;
+            switch(messageState){
+              case ChatMsg.messageStateDelivered:
+                icon = IconSource.done;
+                color = MessageData.of(context).secondaryTextColor;
+                break;
+              case ChatMsg.messageStateReceived:
+                icon = IconSource.doneAll;
+                color = MessageData.of(context).secondaryTextColor;
+                break;
+              case ChatMsg.messageStatePending:
+                icon = IconSource.pending;
+                color = MessageData.of(context).secondaryTextColor;
+                break;
+              case ChatMsg.messageStateFailed:
+                icon = IconSource.error;
+                color = error;
+                break;
+            }
             return Padding(
               padding: EdgeInsets.only(top: 10.0, left: iconTextPadding),
               child: AdaptiveIcon(
                 icon: icon,
                 size: 16.0,
-                color: MessageData.of(context).secondaryTextColor,
+                color: color,
               ),
             );
           }

--- a/lib/src/message/message_item_bloc.dart
+++ b/lib/src/message/message_item_bloc.dart
@@ -122,6 +122,11 @@ class MessageItemBloc extends Bloc<MessageItemEvent, MessageItemState> {
       int showPadlock = await message.showPadlock();
       bool isFlagged = await message.isStarred();
       String teaser = await message.getSummaryText(200);
+      String messageInfo = "";
+      if (state == ChatMsg.messageStateFailed) {
+        Context context = Context();
+        messageInfo = await context.getMessageInfo(_messageId);
+      }
       AttachmentStateData attachmentStateData;
       if (hasFile) {
         attachmentStateData = AttachmentStateData(
@@ -164,6 +169,7 @@ class MessageItemBloc extends Bloc<MessageItemEvent, MessageItemState> {
         showTime: showTime,
         encryptionStatusChanged: encryptionStatusChanged,
         isGroup: isGroup,
+        messageInfo: messageInfo,
       );
       yield MessageItemStateSuccess(messageStateData: messageStateData);
     } catch (error) {
@@ -205,7 +211,7 @@ class MessageItemBloc extends Bloc<MessageItemEvent, MessageItemState> {
     if (!_listenersRegistered) {
       _repositoryStreamHandler = RepositoryMultiEventStreamHandler(
         Type.publish,
-        [Event.msgDelivered, Event.msgRead],
+        [Event.msgDelivered, Event.msgRead, Event.msgFailed, Event.error],
         _onMessageStateChanged,
       );
       _messageListRepository.addListener(_repositoryStreamHandler);
@@ -217,7 +223,7 @@ class MessageItemBloc extends Bloc<MessageItemEvent, MessageItemState> {
     _listenersRegistered = false;
   }
 
-  void _onMessageStateChanged(Event event) {
+  void _onMessageStateChanged(Event event) async{
     var eventMessageId = event.data2;
     if (_messageId == eventMessageId && (event.hasType(Event.msgDelivered) || event.hasType(Event.msgRead))) {
       if (state is MessageItemStateSuccess) {
@@ -228,6 +234,12 @@ class MessageItemBloc extends Bloc<MessageItemEvent, MessageItemState> {
           unregisterListeners();
         }
       }
+    }else if (event.hasType(Event.msgFailed)){
+      int eventMessageState = ChatMsg.messageStateFailed;
+      Context context = Context();
+      String messageInfo = await context.getMessageInfo(_messageId);
+      var messageStateData = (state as MessageItemStateSuccess).messageStateData.copyWith(state: eventMessageState, messageInfo: messageInfo);
+      add(MessageUpdated(messageStateData: messageStateData));
     }
   }
 

--- a/lib/src/message/message_item_bloc.dart
+++ b/lib/src/message/message_item_bloc.dart
@@ -211,7 +211,7 @@ class MessageItemBloc extends Bloc<MessageItemEvent, MessageItemState> {
     if (!_listenersRegistered) {
       _repositoryStreamHandler = RepositoryMultiEventStreamHandler(
         Type.publish,
-        [Event.msgDelivered, Event.msgRead, Event.msgFailed, Event.error],
+        [Event.msgDelivered, Event.msgRead, Event.msgFailed],
         _onMessageStateChanged,
       );
       _messageListRepository.addListener(_repositoryStreamHandler);
@@ -234,11 +234,12 @@ class MessageItemBloc extends Bloc<MessageItemEvent, MessageItemState> {
           unregisterListeners();
         }
       }
-    }else if (event.hasType(Event.msgFailed)){
+    }else if (event.hasType(Event.msgFailed) && _messageId == event.data2){
       int eventMessageState = ChatMsg.messageStateFailed;
       Context context = Context();
       String messageInfo = await context.getMessageInfo(_messageId);
       var messageStateData = (state as MessageItemStateSuccess).messageStateData.copyWith(state: eventMessageState, messageInfo: messageInfo);
+      unregisterListeners();
       add(MessageUpdated(messageStateData: messageStateData));
     }
   }

--- a/lib/src/message/message_item_event_state.dart
+++ b/lib/src/message/message_item_event_state.dart
@@ -133,6 +133,7 @@ class MessageStateData extends Equatable {
   final bool showTime;
   final bool encryptionStatusChanged;
   final bool isGroup;
+  final String messageInfo;
 
   MessageStateData({
     @required this.text,
@@ -151,6 +152,7 @@ class MessageStateData extends Equatable {
     @required this.showTime,
     @required this.encryptionStatusChanged,
     @required this.isGroup,
+    @required this.messageInfo,
   });
 
   MessageStateData copyWith(
@@ -169,7 +171,8 @@ class MessageStateData extends Equatable {
       isFlagged,
       showTime,
       encryptionStatusChanged,
-      isGroup}) {
+      isGroup,
+      messageInfo}) {
     return MessageStateData(
       text: text ?? this.text,
       informationText: informationText ?? this.informationText,
@@ -187,6 +190,7 @@ class MessageStateData extends Equatable {
       showTime: showTime ?? this.showTime,
       encryptionStatusChanged: encryptionStatusChanged ?? this.encryptionStatusChanged,
       isGroup: isGroup ?? this.isGroup,
+      messageInfo: messageInfo ?? this.messageInfo,
     );
   }
 

--- a/lib/src/message/message_list_bloc.dart
+++ b/lib/src/message/message_list_bloc.dart
@@ -99,6 +99,8 @@ class MessageListBloc extends Bloc<MessageListEvent, MessageListState> with Invi
       }
     } else if (event is DeleteCacheFile) {
       _deleteCacheFile(event.path);
+    } else if (event is RetrySendingPendingMessages) {
+      _retrySendingPendingMessages();
     }
   }
 
@@ -191,5 +193,10 @@ class MessageListBloc extends Bloc<MessageListEvent, MessageListState> with Invi
     }
 
     await _context.createChatAttachmentMessage(_chatId, path, fileType, mimeType, duration, text);
+  }
+
+  void _retrySendingPendingMessages() async{
+    Context context = Context();
+    await context.retrySendingPendingMessages();
   }
 }

--- a/lib/src/message/message_list_event_state.dart
+++ b/lib/src/message/message_list_event_state.dart
@@ -76,6 +76,8 @@ class DeleteCacheFile extends MessageListEvent{
   DeleteCacheFile({this.path});
 }
 
+class RetrySendingPendingMessages extends MessageListEvent{}
+
 abstract class MessageListState {}
 
 class MessagesStateInitial extends MessageListState {}

--- a/lib/src/navigation/navigatable.dart
+++ b/lib/src/navigation/navigatable.dart
@@ -77,6 +77,7 @@ enum Type {
   loginManualSettings,
   loginProviderSignIn,
   loginErrorDialog,
+  messageInfoDialog,
   profile,
   search,
   settings,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -172,7 +172,7 @@ packages:
   delta_chat_core:
     dependency: "direct main"
     description:
-      path: "../flutter-deltachat-core"
+      path: "..\\flutter-deltachat-core"
       relative: true
     source: path
     version: "0.0.1"


### PR DESCRIPTION
**Link to the given issue**
https://github.com/open-xchange/ox-coi/issues/255

**Describe what the problem was / what the new feature is**
There is no visual feedback to the user when the send of a message failed or the message is in pending mode.

**Describe your solution**
Added new icons to visualize missing states and added different message actions.

**Additional context**
- Localized hardcoded action Strings.
- Add iOS part in plugin before merge: https://github.com/open-xchange/flutter-deltachat-core/pull/67