### PR TITLE
iOS appbar title font is black

### DIFF
--- a/lib/src/adaptiveWidgets/adaptive_app_bar.dart
+++ b/lib/src/adaptiveWidgets/adaptive_app_bar.dart
@@ -37,6 +37,7 @@ class AdaptiveAppBar extends AdaptiveWidget<CupertinoTheme, AppBar> with Preferr
   CupertinoTheme buildCupertinoWidget(BuildContext context) {
     return CupertinoTheme(
       data: CupertinoThemeData(
+        brightness: Brightness.dark,
         primaryColor: onPrimary,
         barBackgroundColor: primary,
         ),
@@ -44,10 +45,7 @@ class AdaptiveAppBar extends AdaptiveWidget<CupertinoTheme, AppBar> with Preferr
         key: childKey,
         leading: leadingIcon,
         padding: EdgeInsetsDirectional.fromSTEB(0.0, 0.0, 0.0, 0.0),
-        middle: Padding(
-          padding: EdgeInsets.fromLTRB(0.0, 3.0, 0.0, 0.0),
-          child: title,
-        ),
+        middle: title,
         backgroundColor: color,
         actionsForegroundColor: Colors.white,
         trailing: actions != null


### PR DESCRIPTION
**Link to the given issue**
#309 

**Describe what the problem was / what the new feature is**
The black text color is now white.

**Describe your solution**
For now just changed the brightness mode. As a long term fix https://github.com/open-xchange/ox-coi/issues/258 will be used.

**Additional context**
Removed unnecessary border.
