### PR TITLE
OT-582 Unaccessible path for key export/import

### DIFF
--- a/ios/OX Coi/Info.plist
+++ b/ios/OX Coi/Info.plist
@@ -91,5 +91,9 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+	<key>LSSupportsOpeningDocumentsInPlace</key>
+	<true/>
+	<key>UIFileSharingEnabled</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
**Link to the given issue**
https://jira.open-xchange.com/browse/OT-582

**Describe what the problem was / what the new feature is**
We want to expose exported app files to the iOS system (e.g. the Files app), so the user can use the exported / saved data.

**Describe your solution**
We use path_provider with the getApplicationDocumentsDirectory() method which uses the `NSDocumentDirectory` API. This seems to be the right approach, but we also have to adjust our Info.plist to allow the system accessing the folder.

**Additional context**
Information found here https://stackoverflow.com/questions/55220612/how-to-save-a-text-file-in-external-storage-in-ios-using-flutter
