### PR TITLE
Push: remove notifications when entering a conversation manually #196

### DIFF
--- a/lib/src/chat/chat.dart
+++ b/lib/src/chat/chat.dart
@@ -129,6 +129,7 @@ class _ChatState extends State<Chat> with ChatComposer, ChatCreateMixin, InviteM
     super.initState();
     navigation.current = Navigatable(Type.chat, params: [widget.chatId]);
     _chatBloc.add(RequestChat(chatId: widget.chatId, isHeadless: widget.headlessStart, messageId: widget.messageId));
+    _chatBloc.add(ClearNotifications());
     final chatObservable = new Observable<ChatState>(_chatBloc);
     chatObservable.listen((state) {
       if (state is ChatStateSuccess) {

--- a/lib/src/chat/chat_bloc.dart
+++ b/lib/src/chat/chat_bloc.dart
@@ -54,6 +54,7 @@ import 'package:ox_coi/src/data/repository_manager.dart';
 import 'package:ox_coi/src/data/repository_stream_handler.dart';
 import 'package:ox_coi/src/l10n/l.dart';
 import 'package:ox_coi/src/l10n/l10n.dart';
+import 'package:ox_coi/src/notifications/notification_manager.dart';
 import 'package:ox_coi/src/ui/color.dart';
 
 class ChatBloc extends Bloc<ChatEvent, ChatState> {
@@ -97,6 +98,8 @@ class ChatBloc extends Bloc<ChatEvent, ChatState> {
           avatarPath: event.avatarPath,
           isRemoved: event.isRemoved,
           phoneNumbers: event.phoneNumbers);
+    } else if(event is ClearNotifications){
+      _removeNotifications();
     }
   }
 
@@ -207,5 +210,10 @@ class ChatBloc extends Bloc<ChatEvent, ChatState> {
         phoneNumbers: phoneNumbers,
       ),
     );
+  }
+
+  void _removeNotifications() {
+    var _notificationManager = NotificationManager();
+    _notificationManager.cancelNotification(_chatId);
   }
 }

--- a/lib/src/chat/chat_event_state.dart
+++ b/lib/src/chat/chat_event_state.dart
@@ -54,6 +54,8 @@ class RequestChat extends ChatEvent {
   RequestChat({@required this.chatId, this.isHeadless, this.messageId});
 }
 
+class ClearNotifications extends ChatEvent {}
+
 class ChatLoaded extends ChatEvent {
   final String name;
   final String subTitle;


### PR DESCRIPTION
**Link to the given issue**
https://github.com/open-xchange/ox-coi/issues/196

**Describe what the problem was / what the new feature is**
The notifications for a chat where not removed after entering the chat.

**Describe your solution**
Added a call to ChatBloc to cancel the notifications for the specified chatId.