### PR TITLE
OT-574 Files app instead of photo app is used for GIF selection

### DIFF
--- a/lib/src/chat/chat.dart
+++ b/lib/src/chat/chat.dart
@@ -658,11 +658,6 @@ class _ChatState extends State<Chat> with ChatComposer, ChatCreateMixin, InviteM
                 onTap: () => _getFilePath(FileType.CUSTOM, "pdf"),
               ),
               ListTile(
-                leading: AdaptiveIcon(icon: IconSource.gif),
-                title: Text(gif),
-                onTap: () => _getFilePath(FileType.CUSTOM, "gif"),
-              ),
-              ListTile(
                 leading: AdaptiveIcon(icon: IconSource.insertDriveFile),
                 title: Text(L10n.get(L.file)),
                 onTap: () => _getFilePath(FileType.ANY),


### PR DESCRIPTION
**Link to the given issue**
https://jira.open-xchange.com/browse/OT-574

**Describe what the problem was / what the new feature is**
Files app instead of photo app is used for GIF selection

**Describe your solution**
Removed GIF selection, users can use Image / Video to add GIFs to conversations. The GIF entry will later return with proper integration of e.g. external GIF services.
