### PR TITLE
OT-598 No Option to add an unblocked unknown user to contacts

### DIFF
--- a/lib/src/contact/contact_change_bloc.dart
+++ b/lib/src/contact/contact_change_bloc.dart
@@ -164,8 +164,8 @@ class ContactChangeBloc extends Bloc<ContactChangeEvent, ContactChangeState> wit
     Context context = Context();
     await context.unblockContact(id);
     var address = await contact.getAddress();
-    var isKnownContact = await context.isKnownContact(address);
-    if (!isKnownContact) {
+    var contactId = await context.getContactIdByAddress(address);
+    if (contactId == 0) {
       var name = await contact.getName();
       await context.createContact(name, address);
     }

--- a/lib/src/contact/contact_change_bloc.dart
+++ b/lib/src/contact/contact_change_bloc.dart
@@ -160,8 +160,15 @@ class ContactChangeBloc extends Bloc<ContactChangeEvent, ContactChangeState> wit
   }
 
   void _unblockContact(int id) async {
+    var contact = contactRepository.get(id);
     Context context = Context();
     await context.unblockContact(id);
+    var address = await contact.getAddress();
+    var isKnownContact = await context.isKnownContact(address);
+    if (!isKnownContact) {
+      var name = await contact.getName();
+      await context.createContact(name, address);
+    }
     var chatId = await context.getChatByContactId(id);
     adjustChatListOnBlockUnblock(chatId, block: false);
     add(ContactUnblocked());


### PR DESCRIPTION
**Link to the given issue**
https://jira.open-xchange.com/browse/OT-598 (internal ticket only)

**Describe what the problem was / what the new feature is**
Contacts weren't visible after unblocking, if a contact wasn't added in before blocking.

**Describe your solution**
Now checking if an unblocked contact is know and in the database, otherwise it's added now.

**Additional context**
Requires https://github.com/open-xchange/flutter-deltachat-core/pull/73 to be merged.
