### PR TITLE
E-mail address and ISP login assumed to be the same #346

### DIFF
--- a/lib/src/l10n/l.dart
+++ b/lib/src/l10n/l.dart
@@ -243,6 +243,7 @@ class L {
   // Response from server address X with error code Y (e.g. Response from provide.com: Login failed)
   static final loginErrorResponseXY = _translationKey("Response from %s: %s\n\nSome providers place additional information in your inbox; you can check them eg. in the web frontend. Consult your provider or friends if you run into problems.");
   static final loginSignIn = _translationKey("Sign in");
+  static final loginImapSmtpName = _translationKey("IMAP/SMTP login names");
   static final loginServerAddresses = _translationKey("Server addresses");
   static final loginManualSetupRequired = _translationKey("We could not determine all settings automatically.");
 

--- a/lib/src/login/login_manual_settings.dart
+++ b/lib/src/login/login_manual_settings.dart
@@ -140,7 +140,7 @@ class _LoginManualSettingsState extends State<LoginManualSettings> {
               imapPort: state.imapPort,
               imapSecurity: state.imapSecurity,
               smtpLogin: state.smtpLogin,
-              smtpPassword: state.password,
+              smtpPassword: state.smtpPassword,
               smtpServer: state.smtpServer,
               smtpPort: state.smtpPort,
               smtpSecurity: state.smtpSecurity,

--- a/lib/src/settings/settings_manual_form.dart
+++ b/lib/src/settings/settings_manual_form.dart
@@ -49,10 +49,9 @@ import 'package:ox_coi/src/settings/settings_manual_form_event_state.dart';
 import 'package:ox_coi/src/ui/custom_theme.dart';
 import 'package:ox_coi/src/ui/dimensions.dart';
 import 'package:ox_coi/src/ui/strings.dart';
-import 'package:ox_coi/src/ui/text_styles.dart';
 import 'package:ox_coi/src/utils/core.dart';
-import 'package:ox_coi/src/widgets/validatable_text_form_field.dart';
 import 'package:ox_coi/src/utils/keyMapping.dart';
+import 'package:ox_coi/src/widgets/validatable_text_form_field.dart';
 
 class SettingsManualForm extends StatefulWidget {
   final bool isLogin;
@@ -87,7 +86,9 @@ class _SettingsManualFormState extends State<SettingsManualForm> {
     needValidation: true,
     validationHint: (context) => L10n.get(L.loginCheckPort),
   );
-  ValidatableTextFormField smtpLoginNameField = ValidatableTextFormField((context) => L10n.get(L.settingSMTPLogin));
+  ValidatableTextFormField smtpLoginNameField = ValidatableTextFormField(
+    (context) => L10n.get(L.settingSMTPLogin),
+  );
   ValidatableTextFormField smtpPasswordField = ValidatableTextFormField(
     (context) => L10n.get(L.settingSMTPPassword),
     textFormType: TextFormType.password,
@@ -148,9 +149,11 @@ class _SettingsManualFormState extends State<SettingsManualForm> {
               success: success,
               email: emailField.controller.text,
               password: passwordField.controller.text,
+              imapLogin: imapLoginNameField.controller.text,
               imapServer: imapServerField.controller.text,
               imapPort: imapPortField.controller.text,
               imapSecurity: convertProtocolStringToInt(context, selectedImapSecurity),
+              smtpLogin: smtpLoginNameField.controller.text,
               smtpServer: smtpServerField.controller.text,
               smtpPort: smtpPortField.controller.text,
               smtpSecurity: convertProtocolStringToInt(context, selectedSmtpSecurity),
@@ -158,71 +161,92 @@ class _SettingsManualFormState extends State<SettingsManualForm> {
           }
         }
       },
-      child: Form(
-        key: formKey,
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: <Widget>[
-            Align(
-              alignment: Alignment.centerLeft,
-              child: Text(
-                L10n.get(L.settingBase),
-                style: Theme.of(context).textTheme.body2.apply(color: CustomTheme.of(context).onBackground),
+      child: BlocBuilder(
+        bloc: BlocProvider.of<SettingsManualFormBloc>(context),
+        builder: (context, state) {
+          if (state is SettingsManualFormStateReady) {
+            return Form(
+              key: formKey,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: <Widget>[
+                  Align(
+                    alignment: Alignment.centerLeft,
+                    child: Text(
+                      L10n.get(L.settingBase),
+                      style: Theme.of(context).textTheme.body2.apply(color: CustomTheme.of(context).onBackground),
+                    ),
+                  ),
+                  emailField,
+                  passwordField,
+                  Padding(padding: EdgeInsets.all(loginVerticalPadding12dp)),
+                  Align(
+                    alignment: Alignment.centerLeft,
+                    child: Text(
+                      L10n.get(L.loginImapSmtpName),
+                      style: Theme.of(context).textTheme.body2.apply(color: CustomTheme.of(context).onBackground),
+                    ),
+                  ),
+                  imapLoginNameField,
+                  smtpLoginNameField,
+                  Padding(padding: EdgeInsets.all(loginVerticalPadding12dp)),
+                  Align(
+                    alignment: Alignment.centerLeft,
+                    child: Text(
+                      L10n.get(L.loginServerAddresses),
+                      style: Theme.of(context).textTheme.body2.apply(color: CustomTheme.of(context).onBackground),
+                    ),
+                  ),
+                  imapServerField,
+                  smtpServerField,
+                  Padding(padding: EdgeInsets.all(loginVerticalPadding12dp)),
+                  Align(
+                    alignment: Alignment.centerLeft,
+                    child: Text(
+                      L10n.get(L.settingAdvancedImap),
+                      style: Theme.of(context).textTheme.body2.apply(color: CustomTheme.of(context).onBackground),
+                    ),
+                  ),
+                  imapPortField,
+                  Padding(padding: EdgeInsets.all(loginVerticalPadding12dp)),
+                  Text(L10n.get(L.settingIMAPSecurity)),
+                  DropdownButton(
+                      value: selectedImapSecurity == null ? L10n.get(L.automatic) : selectedImapSecurity,
+                      items: getSecurityOptions(context),
+                      onChanged: (String newValue) {
+                        setState(() {
+                          selectedImapSecurity = newValue;
+                        });
+                      }),
+                  Padding(padding: EdgeInsets.all(loginVerticalPadding12dp)),
+                  Align(
+                    alignment: Alignment.centerLeft,
+                    child: Text(
+                      L10n.get(L.settingAdvancedSmtp),
+                      style: Theme.of(context).textTheme.body2.apply(color: CustomTheme.of(context).onBackground),
+                    ),
+                  ),
+                  smtpPortField,
+                  Padding(padding: EdgeInsets.all(loginVerticalPadding12dp)),
+                  Text(L10n.get(L.settingSMTPSecurity)),
+                  DropdownButton(
+                    value: selectedSmtpSecurity == null ? L10n.get(L.automatic) : selectedSmtpSecurity,
+                    items: getSecurityOptions(context),
+                    onChanged: (String newValue) {
+                      setState(() {
+                        selectedSmtpSecurity = newValue;
+                      });
+                    },
+                  ),
+                ],
               ),
-            ),
-            emailField,
-            passwordField,
-            Padding(padding: EdgeInsets.all(loginVerticalPadding12dp)),
-            Align(
-              alignment: Alignment.centerLeft,
-              child: Text(
-                L10n.get(L.loginServerAddresses),
-                style: Theme.of(context).textTheme.body2.apply(color: CustomTheme.of(context).onBackground),
-              ),
-            ),
-            imapServerField,
-            smtpServerField,
-            Padding(padding: EdgeInsets.all(loginVerticalPadding12dp)),
-            Align(
-              alignment: Alignment.centerLeft,
-              child: Text(
-                L10n.get(L.settingAdvancedImap),
-                style: Theme.of(context).textTheme.body2.apply(color: CustomTheme.of(context).onBackground),
-              ),
-            ),
-            imapPortField,
-            Padding(padding: EdgeInsets.all(loginVerticalPadding12dp)),
-            Text(L10n.get(L.settingIMAPSecurity)),
-            DropdownButton(
-                value: selectedImapSecurity == null ? L10n.get(L.automatic) : selectedImapSecurity,
-                items: getSecurityOptions(context),
-                onChanged: (String newValue) {
-                  setState(() {
-                    selectedImapSecurity = newValue;
-                  });
-                }),
-            Padding(padding: EdgeInsets.all(loginVerticalPadding12dp)),
-            Align(
-              alignment: Alignment.centerLeft,
-              child: Text(
-                L10n.get(L.settingAdvancedSmtp),
-                style: Theme.of(context).textTheme.body2.apply(color: CustomTheme.of(context).onBackground),
-              ),
-            ),
-            smtpPortField,
-            Padding(padding: EdgeInsets.all(loginVerticalPadding12dp)),
-            Text(L10n.get(L.settingSMTPSecurity)),
-            DropdownButton(
-              value: selectedSmtpSecurity == null ? L10n.get(L.automatic) : selectedSmtpSecurity,
-              items: getSecurityOptions(context),
-              onChanged: (String newValue) {
-                setState(() {
-                  selectedSmtpSecurity = newValue;
-                });
-              },
-            ),
-          ],
-        ),
+            );
+          } else {
+            return CircularProgressIndicator(
+              valueColor: AlwaysStoppedAnimation<Color>(CustomTheme.of(context).onSurface),
+            );
+          }
+        },
       ),
     );
   }

--- a/lib/src/settings/settings_manual_form.dart
+++ b/lib/src/settings/settings_manual_form.dart
@@ -92,7 +92,7 @@ class _SettingsManualFormState extends State<SettingsManualForm> {
   ValidatableTextFormField smtpPasswordField = ValidatableTextFormField(
     (context) => L10n.get(L.settingSMTPPassword),
     textFormType: TextFormType.password,
-    needValidation: true,
+    needValidation: false,
     validationHint: (context) => L10n.get(L.loginCheckPassword),
   );
   ValidatableTextFormField smtpServerField = ValidatableTextFormField(
@@ -154,6 +154,7 @@ class _SettingsManualFormState extends State<SettingsManualForm> {
               imapPort: imapPortField.controller.text,
               imapSecurity: convertProtocolStringToInt(context, selectedImapSecurity),
               smtpLogin: smtpLoginNameField.controller.text,
+              smtpPassword: smtpPasswordField.controller.text,
               smtpServer: smtpServerField.controller.text,
               smtpPort: smtpPortField.controller.text,
               smtpSecurity: convertProtocolStringToInt(context, selectedSmtpSecurity),
@@ -164,7 +165,7 @@ class _SettingsManualFormState extends State<SettingsManualForm> {
       child: BlocBuilder(
         bloc: BlocProvider.of<SettingsManualFormBloc>(context),
         builder: (context, state) {
-          if (state is SettingsManualFormStateReady) {
+          if (state is SettingsManualFormStateReady || state is SettingsManualFormStateValidation || state is SettingsManualFormStateValidationSuccess) {
             return Form(
               key: formKey,
               child: Column(
@@ -189,6 +190,7 @@ class _SettingsManualFormState extends State<SettingsManualForm> {
                   ),
                   imapLoginNameField,
                   smtpLoginNameField,
+                  smtpPasswordField,
                   Padding(padding: EdgeInsets.all(loginVerticalPadding12dp)),
                   Align(
                     alignment: Alignment.centerLeft,
@@ -242,9 +244,7 @@ class _SettingsManualFormState extends State<SettingsManualForm> {
               ),
             );
           } else {
-            return CircularProgressIndicator(
-              valueColor: AlwaysStoppedAnimation<Color>(CustomTheme.of(context).onSurface),
-            );
+            return Container();
           }
         },
       ),

--- a/lib/src/settings/settings_manual_form.dart
+++ b/lib/src/settings/settings_manual_form.dart
@@ -162,8 +162,7 @@ class _SettingsManualFormState extends State<SettingsManualForm> {
           }
         }
       },
-      child: BlocBuilder(
-        bloc: BlocProvider.of<SettingsManualFormBloc>(context),
+      child: BlocBuilder<SettingsManualFormBloc, SettingsManualFormState>(
         builder: (context, state) {
           if (state is SettingsManualFormStateReady || state is SettingsManualFormStateValidation || state is SettingsManualFormStateValidationSuccess) {
             return Form(

--- a/lib/src/settings/settings_manual_form_bloc.dart
+++ b/lib/src/settings/settings_manual_form_bloc.dart
@@ -85,6 +85,7 @@ class SettingsManualFormBloc extends Bloc<SettingsManualFormEvent, SettingsManua
           imapPort: event.imapPort,
           imapSecurity: event.imapSecurity,
           smtpLogin: event.smtpLogin,
+          smtpPassword: event.smtpPassword,
           smtpServer: event.smtpServer,
           smtpPort: event.smtpPort,
           smtpSecurity: event.smtpSecurity,

--- a/lib/src/settings/settings_manual_form_bloc.dart
+++ b/lib/src/settings/settings_manual_form_bloc.dart
@@ -80,9 +80,11 @@ class SettingsManualFormBloc extends Bloc<SettingsManualFormEvent, SettingsManua
         yield SettingsManualFormStateValidationSuccess(
           email: event.email,
           password: event.password,
+          imapLogin: event.imapLogin,
           imapServer: event.imapServer,
           imapPort: event.imapPort,
           imapSecurity: event.imapSecurity,
+          smtpLogin: event.smtpLogin,
           smtpServer: event.smtpServer,
           smtpPort: event.smtpPort,
           smtpSecurity: event.smtpSecurity,

--- a/lib/src/settings/settings_manual_form_event_state.dart
+++ b/lib/src/settings/settings_manual_form_event_state.dart
@@ -89,6 +89,7 @@ class ValidationDone extends SettingsManualFormEvent {
   final String imapServer;
   final String imapPort;
   final String smtpLogin;
+  final String smtpPassword;
   final String smtpServer;
   final String smtpPort;
   final int imapSecurity;
@@ -102,6 +103,7 @@ class ValidationDone extends SettingsManualFormEvent {
     this.imapServer,
     this.imapPort,
     this.smtpLogin,
+    this.smtpPassword,
     this.smtpServer,
     this.smtpPort,
     this.imapSecurity,
@@ -149,6 +151,7 @@ class SettingsManualFormStateValidationSuccess extends SettingsManualFormState {
   final String imapServer;
   final String imapPort;
   final String smtpLogin;
+  final String smtpPassword;
   final String smtpServer;
   final String smtpPort;
   final int imapSecurity;
@@ -161,6 +164,7 @@ class SettingsManualFormStateValidationSuccess extends SettingsManualFormState {
     this.imapServer,
     this.imapPort,
     this.smtpLogin,
+    this.smtpPassword,
     this.smtpServer,
     this.smtpPort,
     this.imapSecurity,

--- a/lib/src/user/user_account_settings.dart
+++ b/lib/src/user/user_account_settings.dart
@@ -155,7 +155,7 @@ class _UserAccountSettingsState extends State<UserAccountSettings> {
                 imapPort: state.imapPort,
                 imapSecurity: state.imapSecurity,
                 smtpLogin: state.smtpLogin,
-                smtpPassword: state.password,
+                smtpPassword: state.smtpPassword,
                 smtpServer: state.smtpServer,
                 smtpPort: state.smtpPort,
                 smtpSecurity: state.smtpSecurity,

--- a/lib/src/user/user_account_settings.dart
+++ b/lib/src/user/user_account_settings.dart
@@ -165,8 +165,8 @@ class _UserAccountSettingsState extends State<UserAccountSettings> {
         },
         child: Scaffold(
           appBar: AdaptiveAppBar(
-            leadingIcon: new AdaptiveIconButton(
-              icon: new AdaptiveIcon(
+            leadingIcon: AdaptiveIconButton(
+              icon: AdaptiveIcon(
                 icon: IconSource.close,
               ),
               onPressed: () => _navigation.pop(context),

--- a/lib/src/user/user_change_bloc.dart
+++ b/lib/src/user/user_change_bloc.dart
@@ -97,11 +97,11 @@ class UserChangeBloc extends Bloc<UserChangeEvent, UserChangeState> {
 
   void _saveUserAccountData(UserAccountDataChanged event) async {
     Config config = Config();
-    await config.setValue(Context.configMailUser, event.imapLogin);
+    await config.setValue(Context.configMailUser, event.imapLogin.isNotEmpty ? event.imapLogin : null);
     await config.setValue(Context.configMailPassword, event.imapPassword);
     await config.setValue(Context.configMailServer, event.imapServer);
     await config.setValue(Context.configMailPort, event.imapPort);
-    await config.setValue(Context.configSendUser, event.smtpLogin);
+    await config.setValue(Context.configSendUser, event.smtpLogin.isNotEmpty ? event.smtpLogin : null);
     await config.setValue(Context.configSendPassword, event.smtpPassword);
     await config.setValue(Context.configSendServer, event.smtpServer);
     await config.setValue(Context.configSendPort, event.smtpPort);

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -172,7 +172,7 @@ packages:
   delta_chat_core:
     dependency: "direct main"
     description:
-      path: "../flutter-deltachat-core"
+      path: "..\\flutter-deltachat-core"
       relative: true
     source: path
     version: "0.0.1"


### PR DESCRIPTION
**Link to the given issue**
https://github.com/open-xchange/ox-coi/issues/346

**Describe what the problem was / what the new feature is**
The fields for IMAP/SMTP login names were missing in the account settings.

**Describe your solution**
Added the missing fields to the account settings page.

**Additional context**
Fixed a problem of small page jump in the account settings.
