### PR TITLE
Add pre-defined chat #301

### DIFF
--- a/assets/customer/customer_config.json
+++ b/assets/customer/customer_config.json
@@ -1,0 +1,10 @@
+{
+  "name": "Open-Xchange",
+  "chats": [
+    {
+      "email": "oxcoimessenger@open-xchange.com",
+      "name": "Open-Xchange",
+      "deletable": true
+    }
+  ]
+}

--- a/lib/src/customer/customer_config.dart
+++ b/lib/src/customer/customer_config.dart
@@ -40,23 +40,50 @@
  * for more details.
  */
 
-import 'package:ox_coi/src/l10n/l.dart';
-import 'package:ox_coi/src/l10n/l10n.dart';
+class CustomerConfig {
+  String name;
+  List<CustomerChat> chats;
 
-String get sslTls => "SSL/TLS";
+  CustomerConfig({this.name, this.chats});
 
-String get startTLS => "StartTLS";
+  CustomerConfig.fromJson(Map<String, dynamic> json) {
+    name = json['name'];
+    if (json['chats'] != null) {
+      chats = new List<CustomerChat>();
+      json['chats'].forEach((v) {
+        chats.add(new CustomerChat.fromJson(v));
+      });
+    }
+  }
 
-String get projectUrl => "https://coi.me";
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> data = new Map<String, dynamic>();
+    data['name'] = this.name;
+    if (this.chats != null) {
+      data['chats'] = this.chats.map((v) => v.toJson()).toList();
+    }
+    return data;
+  }
+}
 
-String get issueUrl  => "https://github.com/open-xchange/ox-coi/issues";
+class CustomerChat{
+  String name;
+  String email;
+  bool deletable;
 
-String get featureRequestUrl => "https://openxchange.userecho.com/communities/4-ox-coi-messenger";
+  CustomerChat({this.name, this.email, this.deletable});
 
-String get defaultStatus => "${L10n.get(L.profileDefaultStatus)} - $projectUrl";
+  CustomerChat.fromJson(Map<String, dynamic> json) {
+    name = json['name'];
+    email = json['email'];
+    deletable = json['deletable'];
+  }
 
-String get gif =>  "GIF";
-
-String get pdf => "PDF";
-
-String get customerConfigPath => "assets/customer/customer_config.json";
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> data = new Map<String, dynamic>();
+    data['name'] = this.name;
+    data['email'] = this.email;
+    data['deletable'] = this.deletable;
+    return data;
+  }
+}

--- a/lib/src/customer/customer_config.dart
+++ b/lib/src/customer/customer_config.dart
@@ -42,27 +42,26 @@
 
 class CustomerConfig {
   String name;
-  List<CustomerChat> chats = List();
+  var chats = List<CustomerChat>();
 
   CustomerConfig({this.name, this.chats});
 
   CustomerConfig.fromJson(Map<String, dynamic> json) {
     name = json['name'];
-    chats = new List<CustomerChat>();
-    json['chats'].forEach((v) {
-      chats.add(new CustomerChat.fromJson(v));
+    json['chats']?.forEach((v) {
+      chats.add(CustomerChat.fromJson(v));
     });
   }
 
   Map<String, dynamic> toJson() {
-    final Map<String, dynamic> data = new Map<String, dynamic>();
+    final Map<String, dynamic> data = Map<String, dynamic>();
     data['name'] = this.name;
     data['chats'] = this.chats.map((v) => v.toJson()).toList();
     return data;
   }
 }
 
-class CustomerChat{
+class CustomerChat {
   String name;
   String email;
   bool deletable;
@@ -76,7 +75,7 @@ class CustomerChat{
   }
 
   Map<String, dynamic> toJson() {
-    final Map<String, dynamic> data = new Map<String, dynamic>();
+    final Map<String, dynamic> data = Map<String, dynamic>();
     data['name'] = this.name;
     data['email'] = this.email;
     data['deletable'] = this.deletable;

--- a/lib/src/customer/customer_config.dart
+++ b/lib/src/customer/customer_config.dart
@@ -42,26 +42,22 @@
 
 class CustomerConfig {
   String name;
-  List<CustomerChat> chats;
+  List<CustomerChat> chats = List();
 
   CustomerConfig({this.name, this.chats});
 
   CustomerConfig.fromJson(Map<String, dynamic> json) {
     name = json['name'];
-    if (json['chats'] != null) {
-      chats = new List<CustomerChat>();
-      json['chats'].forEach((v) {
-        chats.add(new CustomerChat.fromJson(v));
-      });
-    }
+    chats = new List<CustomerChat>();
+    json['chats'].forEach((v) {
+      chats.add(new CustomerChat.fromJson(v));
+    });
   }
 
   Map<String, dynamic> toJson() {
     final Map<String, dynamic> data = new Map<String, dynamic>();
     data['name'] = this.name;
-    if (this.chats != null) {
-      data['chats'] = this.chats.map((v) => v.toJson()).toList();
-    }
+    data['chats'] = this.chats.map((v) => v.toJson()).toList();
     return data;
   }
 }

--- a/lib/src/login/login_provider_signin.dart
+++ b/lib/src/login/login_provider_signin.dart
@@ -151,7 +151,7 @@ class _ProviderSignInState extends State<ProviderSignIn> {
           title: Text(widget.provider.name),
         ),
         body: createProviderSignIn()
-    );;
+    );
   }
 
   Widget createProviderSignIn() {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -73,6 +73,7 @@ dev_dependencies:
 
 flutter:
   assets:
+    - assets/customer/
     - assets/html/
     - assets/images/
     - assets/json/


### PR DESCRIPTION
**Link to the given issue**
https://github.com/open-xchange/ox-coi/issues/301

**Describe what the problem was / what the new feature is**
It should be possible to show pre-defined chats after login and after updates.

**Describe your solution**
There is a customer_config.json with different informations (name, list of pre-defined chats,...). When the app is configured we load the customer_config and create the chats if needed.

**Additional context**
The "deletable" field has no affect at the moment