### PR TITLE
Scan QR code doesn't work #391

### DIFF
--- a/lib/src/contact/contact_change.dart
+++ b/lib/src/contact/contact_change.dart
@@ -325,7 +325,7 @@ class _ContactChangeState extends State<ContactChange> {
                 icon: IconSource.qr,
                 text: L10n.get(L.qrScan),
                 iconBackground: CustomTheme.of(context).qrIcon,
-                onTap: () => scanQr,
+                onTap: scanQr,
               ),
             ),
           ],

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -647,9 +647,11 @@ packages:
   qr_mobile_vision:
     dependency: "direct main"
     description:
-      name: qr_mobile_vision
-      url: "https://pub.dartlang.org"
-    source: hosted
+      path: "."
+      ref: android-embedding-v2
+      resolved-ref: "0bc7163796e84d5a11c2401b67411615b2c6f7b7"
+      url: "https://github.com/Boehrsi/flutter_qr_mobile_vision"
+    source: git
     version: "0.3.1"
   quiver:
     dependency: transitive

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -55,7 +55,10 @@ dependencies:
   url_launcher: ^5.4.1
   video_player: ^0.10.5+2
   qr_flutter: ^3.2.0
-  qr_mobile_vision: ^0.3.1
+  qr_mobile_vision:
+    git:
+      url: https://github.com/Boehrsi/flutter_qr_mobile_vision
+      ref: android-embedding-v2
   uuid: ^2.0.4
   video_thumbnail: ^0.2.0
   delta_chat_core:


### PR DESCRIPTION

**Link to the given issue**
#391

**Describe what the problem was / what the new feature is**
We called the method wrong.

**Describe your solution**
We call the method the right way:
```
onTap: () => scanQr() // works
onTap: scanQr // works

onTap: () => scanQr // doesn't work
```

**Additional context**
Fixed the dependency to the qr_mobile_vision lib (Android only). We are currently using our fork, as the actual library doesn't support the required Android v2 embedding. As soon the lib integrates v2 embedding we switch back.
