### PR TITLE
Blinking Flutter-Error when entering a chat #392

### DIFF
--- a/lib/src/chat/chat.dart
+++ b/lib/src/chat/chat.dart
@@ -274,7 +274,8 @@ class _ChatState extends State<Chat> with ChatComposer, ChatCreateMixin, InviteM
             appBar: AdaptiveAppBar(
               title: isInviteChat(widget.chatId)
                   ? buildRow(imagePath, name, subTitle, color, context, isVerified)
-                  : InkWell(
+                  : GestureDetector(
+                      behavior: HitTestBehavior.opaque,
                       onTap: () => _chatTitleTapped(),
                       child: buildRow(imagePath, name, subTitle, color, context, isVerified),
                     ),


### PR DESCRIPTION
**Link to the given issue**
#392

**Describe what the problem was / what the new feature is**
We used an InkWell Widget. This requires a top level Material Widget. This wasn't present at the time of creation of the initial widget tree. 

**Describe your solution**
Replaced it with a GestureDetector, which doesn't require a Material Widget.

**Additional context**
@florianhaar we often had the problem with GestureDetectors only recognizing tabs on the child Widgets, but not on the areas inbetween. I just found the Flutter documentation (https://api.flutter.dev/flutter/rendering/HitTestBehavior-class.html) for that problem and the fix is actually pretty simple (`HitTestBehavior.opaque` or similar depending on the wanted behavior).
