### PR TITLE
Contact list flickers on first selection #400

### DIFF
--- a/lib/src/chat/chat_create_group_participants.dart
+++ b/lib/src/chat/chat_create_group_participants.dart
@@ -77,6 +77,7 @@ class _ChatCreateGroupParticipantsState extends State<ChatCreateGroupParticipant
   ContactListBloc _contactListBloc = ContactListBloc();
   Repository<Chat> chatRepository;
   Navigation navigation = Navigation();
+  var _scrollController = ScrollController();
 
   @override
   void initState() {
@@ -159,24 +160,33 @@ class _ChatCreateGroupParticipantsState extends State<ChatCreateGroupParticipant
   }
 
   ListView buildListItems(ContactListStateSuccess state) {
-    return ListView.separated(
-      separatorBuilder: (context, index) => Divider(
-        height: dividerHeight,
-        color: CustomTheme.of(context).onBackground.withOpacity(barely),
-      ),
-      itemCount: state.contactIds.length,
-      itemBuilder: (BuildContext context, int index) {
-        var contactId = state.contactIds[index];
-        var key = createKeyString(contactId, state.contactLastUpdateValues[index]);
-        bool isSelected = state.contactsSelected.contains(contactId);
-        return ContactItemSelectable(
-          contactId: contactId,
-          onTap: _itemTapped,
-          isSelected: isSelected,
-          key: key,
-        );
-      },
-    );
+    var contactIds = state.contactIds;
+    var contactLastUpdateValues = state.contactLastUpdateValues;
+    return ListView.custom(
+        controller: _scrollController,
+        childrenDelegate: SliverChildBuilderDelegate(
+                (BuildContext context, int index) {
+              var contactId = contactIds[index];
+              var key = createKeyFromId(contactId, [contactLastUpdateValues[index]]);
+              bool isSelected = state.contactsSelected.contains(contactId);
+              return ContactItemSelectable(
+                contactId: contactId,
+                onTap: _itemTapped,
+                isSelected: isSelected,
+                key: key,
+              );
+            },
+            childCount: contactIds.length,
+            findChildIndexCallback: (Key key) {
+              final ValueKey valueKey = key;
+              var id = extractId(valueKey);
+              if (contactIds.contains(id)) {
+                var indexOf = contactIds.indexOf(id);
+                return indexOf;
+              } else {
+                return null;
+              }
+            }));
   }
 
   Widget _buildSelectedParticipantList(List<int> selectedContacts) {

--- a/lib/src/contact/contact_item_selectable.dart
+++ b/lib/src/contact/contact_item_selectable.dart
@@ -51,7 +51,7 @@ class ContactItemSelectable extends StatefulWidget {
   final Function onTap;
   final bool isSelected;
 
-  ContactItemSelectable({@required this.contactId, @required this.onTap, @required this.isSelected, key}) : super(key: Key(key));
+  ContactItemSelectable({@required this.contactId, @required this.onTap, @required this.isSelected, key}) : super(key: key);
 
   @override
   _ContactItemSelectableState createState() => _ContactItemSelectableState();


### PR DESCRIPTION
**Link to the given issue**
https://github.com/open-xchange/ox-coi/issues/400

**Describe what the problem was / what the new feature is**
The complete list flickers after selecting a contact in the ChatCreateGroupParticipants view the first time.

**Describe your solution**
Moved the line `List<int> lastUpdates = _contactRepository.getLastUpdateValuesForIds(contactIds);` after setting the phonenumber and avatarImage.

**Additional context**
- Changed ListView.seperated to ListView.custom
- Changed some functions in async* with return type Stream<State>