### PR TITLE
Progress screen doesn't block taps #405

### DIFF
--- a/lib/src/contact/contact_list.dart
+++ b/lib/src/contact/contact_list.dart
@@ -176,10 +176,7 @@ class _ContactListState extends State<ContactList> with ChatCreateMixin {
   }
 
   handleContactImport(ContactImportState state) {
-    if (_progressOverlayEntry != null) {
-      _progressOverlayEntry.remove();
-      _progressOverlayEntry = null;
-    }
+    _progressOverlayEntry?.remove();
     if (state is ContactsImportSuccess) {
       requestValidContacts();
       String contactImportSuccess = L10n.get(L.contactImportSuccessful);
@@ -223,7 +220,7 @@ class _ContactListState extends State<ContactList> with ChatCreateMixin {
                     var key = createKeyFromId(contactId, [contactLastUpdateValues[index]]);
                     return Dismissible(
                       key: key,
-                      confirmDismiss: (direction){
+                      confirmDismiss: (direction) {
                         createChatFromContact(context, contactId);
                         return Future.value(false);
                       },
@@ -299,12 +296,11 @@ class _ContactListState extends State<ContactList> with ChatCreateMixin {
       content: content,
       positiveButton: importPositive,
       positiveAction: () {
-        _progressOverlayEntry = OverlayEntry(
-          builder: (context) => FullscreenProgress(
-            bloc: _contactListBloc,
-            text: L10n.get(L.contactImportRunning),
-          ),
-        );
+        _progressOverlayEntry = FullscreenOverlay(
+            fullscreenProgress: FullscreenProgress(
+          bloc: _contactListBloc,
+          text: L10n.get(L.contactImportRunning),
+        ));
         Overlay.of(context).insert(_progressOverlayEntry);
         _contactImportBloc.add(PerformImport());
       },

--- a/lib/src/login/login_manual_settings.dart
+++ b/lib/src/login/login_manual_settings.dart
@@ -74,24 +74,20 @@ class LoginManualSettings extends StatefulWidget {
 
 class _LoginManualSettingsState extends State<LoginManualSettings> {
   OverlayEntry _progressOverlayEntry;
-  FullscreenProgress _progress;
   LoginBloc _loginBloc;
+  var _navigation = Navigation();
 
   @override
   void initState() {
     super.initState();
-    var navigation = Navigation();
-    navigation.current = Navigatable(Type.loginManualSettings);
+    _navigation.current = Navigatable(Type.loginManualSettings);
     _loginBloc = LoginBloc(BlocProvider.of<ErrorBloc>(context));
     _loginBloc.listen((state) => handleLoginStateChange(state));
   }
 
   void handleLoginStateChange(LoginState state) {
     if (state is LoginStateSuccess || state is LoginStateFailure) {
-      if (_progressOverlayEntry != null) {
-        _progressOverlayEntry.remove();
-        _progressOverlayEntry = null;
-      }
+      _progressOverlayEntry?.remove();
     }
     if (state is LoginStateSuccess) {
       widget.success();
@@ -122,15 +118,14 @@ class _LoginManualSettingsState extends State<LoginManualSettings> {
       child: BlocListener<SettingsManualFormBloc, SettingsManualFormState>(
         listener: (BuildContext context, state) {
           if (state is SettingsManualFormStateValidationSuccess) {
-            _progress = FullscreenProgress(
-              bloc: _loginBloc,
-              text: L10n.get(L.loginRunning),
-              showProgressValues: true,
-              showCancelButton: false,
+            _progressOverlayEntry = FullscreenOverlay(
+              fullscreenProgress: FullscreenProgress(
+                bloc: _loginBloc,
+                text: L10n.get(L.loginRunning),
+                showProgressValues: true,
+              ),
             );
-            _progressOverlayEntry = OverlayEntry(builder: (context) => _progress);
-            OverlayState overlayState = Overlay.of(context);
-            overlayState.insert(_progressOverlayEntry);
+            Overlay.of(context).insert(_progressOverlayEntry);
             _loginBloc.add(LoginButtonPressed(
               email: state.email,
               password: state.password,
@@ -146,51 +141,54 @@ class _LoginManualSettingsState extends State<LoginManualSettings> {
             ));
           }
         },
-        child: Scaffold(
-          appBar: AdaptiveAppBar(
-            title: Text(L10n.get(L.settingManual)),
-            actions: <Widget>[LoginButton()],
-          ),
-          body: Column(
-            children: <Widget>[
-              Expanded(
-                child: SingleChildScrollView(
-                  child: Padding(
-                    padding: EdgeInsets.all(loginManualSettingsPadding),
-                    child: Column(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: <Widget>[
-                        Column(
-                          mainAxisAlignment: MainAxisAlignment.center,
-                          children: <Widget>[
-                            Visibility(
-                              visible: widget.fromError,
-                              child: Text(
-                                L10n.get(L.loginManualSetupRequired),
+        child: WillPopScope(
+          onWillPop: () async => _navigation.allowBackNavigation,
+          child: Scaffold(
+            appBar: AdaptiveAppBar(
+              title: Text(L10n.get(L.settingManual)),
+              actions: <Widget>[LoginButton()],
+            ),
+            body: Column(
+              children: <Widget>[
+                Expanded(
+                  child: SingleChildScrollView(
+                    child: Padding(
+                      padding: EdgeInsets.all(loginManualSettingsPadding),
+                      child: Column(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: <Widget>[
+                          Column(
+                            mainAxisAlignment: MainAxisAlignment.center,
+                            children: <Widget>[
+                              Visibility(
+                                visible: widget.fromError,
+                                child: Text(
+                                  L10n.get(L.loginManualSetupRequired),
+                                ),
                               ),
-                            ),
-                            Padding(padding: EdgeInsets.all(loginManualSettingsSubTitlePadding)),
-                            Text(
-                              L10n.get(L.loginCheckServer),
-                              textAlign: TextAlign.center,
-                            ),
-                            Padding(padding: EdgeInsets.all(loginManualSettingsSubTitlePadding)),
-                            Text(
-                              L10n.get(L.loginWelcomeManual),
-                              textAlign: TextAlign.center,
-                            ),
-                          ],
-                        ),
-                        Padding(
-                          padding: const EdgeInsets.only(top: loginVerticalPadding),
-                          child: SettingsManualForm(isLogin: true),
-                        ),
-                      ],
+                              Padding(padding: EdgeInsets.all(loginManualSettingsSubTitlePadding)),
+                              Text(
+                                L10n.get(L.loginCheckServer),
+                                textAlign: TextAlign.center,
+                              ),
+                              Padding(padding: EdgeInsets.all(loginManualSettingsSubTitlePadding)),
+                              Text(
+                                L10n.get(L.loginWelcomeManual),
+                                textAlign: TextAlign.center,
+                              ),
+                            ],
+                          ),
+                          Padding(
+                            padding: const EdgeInsets.only(top: loginVerticalPadding),
+                            child: SettingsManualForm(isLogin: true),
+                          ),
+                        ],
+                      ),
                     ),
                   ),
-                ),
-              )
-            ],
+                )
+              ],
+            ),
           ),
         ),
       ),

--- a/lib/src/login/login_provider_signin.dart
+++ b/lib/src/login/login_provider_signin.dart
@@ -63,7 +63,6 @@ import 'login_events_state.dart';
 import 'login_manual_settings.dart';
 
 class ProviderSignIn extends StatefulWidget {
-
   final Provider provider;
   final Function success;
 
@@ -115,10 +114,7 @@ class _ProviderSignInState extends State<ProviderSignIn> {
       return;
     }
     if (state is LoginStateSuccess || state is LoginStateFailure) {
-      if (_progressOverlayEntry != null) {
-        _progressOverlayEntry.remove();
-        _progressOverlayEntry = null;
-      }
+      _progressOverlayEntry?.remove();
     }
     if (state is LoginStateSuccess) {
       widget.success();
@@ -146,11 +142,13 @@ class _ProviderSignInState extends State<ProviderSignIn> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-        appBar: AdaptiveAppBar(
-          title: Text(widget.provider.name),
-        ),
-        body: createProviderSignIn()
+    return WillPopScope(
+      onWillPop: () async => _navigation.allowBackNavigation,
+      child: Scaffold(
+          appBar: AdaptiveAppBar(
+            title: Text(widget.provider.name),
+          ),
+          body: createProviderSignIn()),
     );
   }
 
@@ -215,12 +213,11 @@ class _ProviderSignInState extends State<ProviderSignIn> {
     var password = passwordField.controller.text;
 
     if (simpleLoginIsValid) {
-      _progressOverlayEntry = OverlayEntry(
-        builder: (context) => FullscreenProgress(
+      _progressOverlayEntry = FullscreenOverlay(
+        fullscreenProgress: FullscreenProgress(
           bloc: _loginBloc,
           text: L10n.get(L.loginRunning),
           showProgressValues: true,
-          showCancelButton: false,
         ),
       );
       Overlay.of(context).insert(_progressOverlayEntry);
@@ -229,10 +226,7 @@ class _ProviderSignInState extends State<ProviderSignIn> {
   }
 
   void _closeError() {
-    if (_overlayEntry != null) {
-      _overlayEntry.remove();
-      _overlayEntry = null;
-    }
+    _overlayEntry?.remove();
   }
 
   void _showManualSettings() {

--- a/lib/src/main/root.dart
+++ b/lib/src/main/root.dart
@@ -108,6 +108,7 @@ class _RootState extends State<Root> {
       ),
       backgroundColor: CustomTheme.of(context).background,
       body: WillPopScope(
+        onWillPop: _onWillPop,
         child: MultiBlocListener(
           listeners: [
             BlocListener<LifecycleBloc, LifecycleState>(
@@ -200,7 +201,6 @@ class _RootState extends State<Root> {
           ],
           child: ViewSwitcher(child),
         ),
-        onWillPop: _onWillPop,
       ),
       bottomNavigationBar: BottomNavigationBar(
         type: BottomNavigationBarType.fixed,
@@ -224,6 +224,9 @@ class _RootState extends State<Root> {
   }
 
   Future<bool> _onWillPop() {
+    if (!_navigation.allowBackNavigation) {
+      return Future.value(false);
+    }
     if (_selectedIndex != 0) {
       setState(() {
         _selectedIndex = 0;

--- a/lib/src/navigation/navigation.dart
+++ b/lib/src/navigation/navigation.dart
@@ -98,6 +98,8 @@ class Navigation {
 
   Navigatable get current => _navigationStack.isEmpty ? null : _navigationStack.last;
 
+  bool allowBackNavigation = true;
+
   set current(Navigatable navigatable) {
     _logger.info("Set current: ${navigatable.tag}");
     _navigationStack.add(navigatable);

--- a/lib/src/qr/qr.dart
+++ b/lib/src/qr/qr.dart
@@ -63,7 +63,7 @@ class QrCode extends StatefulWidget {
 
 class _QrCodeState extends State<QrCode> with SingleTickerProviderStateMixin {
   TabController controller;
-  Navigation navigation = Navigation();
+  Navigation _navigation = Navigation();
 
   @override
   void initState() {
@@ -73,12 +73,15 @@ class _QrCodeState extends State<QrCode> with SingleTickerProviderStateMixin {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AdaptiveAppBar(
-        elevation: zero,
-        title: Text(L10n.get(L.qrProfile)),
+    return WillPopScope(
+      onWillPop: () async => _navigation.allowBackNavigation,
+      child: Scaffold(
+        appBar: AdaptiveAppBar(
+          elevation: zero,
+          title: Text(L10n.get(L.qrProfile)),
+        ),
+        body: buildBody(),
       ),
-      body: buildBody(),
     );
   }
 

--- a/lib/src/qr/scan_qr.dart
+++ b/lib/src/qr/scan_qr.dart
@@ -84,7 +84,7 @@ class _ScanQrState extends State<ScanQr> {
         } else {
           showToast(L10n.get(L.errorProgressCanceled));
         }
-        _progressOverlayEntry.remove();
+        _progressOverlayEntry?.remove();
       } else if (state is QrStateFailure) {
         _qrCodeDetected = false;
 
@@ -144,22 +144,21 @@ class _ScanQrState extends State<ScanQr> {
   }
 
   void checkAndJoinQr(String qrString) {
-    _progressOverlayEntry = OverlayEntry(
-      builder: (context) =>
-          FullscreenProgress(
-            bloc: _qrBloc,
-            text: L10n.get(L.pleaseWait),
-            showProgressValues: false,
-            showCancelButton: true,
-            cancelPressed: _cancelPressed,
-          ),
+    _progressOverlayEntry = FullscreenOverlay(
+      fullscreenProgress: FullscreenProgress(
+        bloc: _qrBloc,
+        text: L10n.get(L.pleaseWait),
+        showProgressValues: false,
+        showCancelButton: true,
+        cancelPressed: _cancelPressed,
+      ),
     );
     Overlay.of(context).insert(_progressOverlayEntry);
     _qrBloc.add(CheckQr(qrText: qrString));
   }
 
   void _cancelPressed() {
-    _progressOverlayEntry.remove();
+    _progressOverlayEntry?.remove();
     _qrCodeDetected = false;
     _qrBloc.add(CancelQrProcess());
   }

--- a/lib/src/settings/settings_security.dart
+++ b/lib/src/settings/settings_security.dart
@@ -40,8 +40,9 @@
  * for more details.
  */
 
-import 'package:flutter/material.dart';
 import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:ox_coi/src/adaptiveWidgets/adaptive_app_bar.dart';
 import 'package:ox_coi/src/l10n/l.dart';
 import 'package:ox_coi/src/l10n/l10n.dart';
 import 'package:ox_coi/src/navigation/navigatable.dart';
@@ -56,23 +57,20 @@ import 'package:ox_coi/src/utils/text.dart';
 import 'package:ox_coi/src/utils/toast.dart';
 import 'package:ox_coi/src/widgets/fullscreen_progress.dart';
 
-import 'package:ox_coi/src/adaptiveWidgets/adaptive_app_bar.dart';
-
 class SettingsSecurity extends StatefulWidget {
   @override
   _SettingsSecurityState createState() => _SettingsSecurityState();
 }
 
 class _SettingsSecurityState extends State<SettingsSecurity> {
-  final Navigation navigation = Navigation();
+  final Navigation _navigation = Navigation();
   OverlayEntry _progressOverlayEntry;
   SettingsSecurityBloc _settingsSecurityBloc = SettingsSecurityBloc();
-  bool _enableBack = true;
 
   @override
   void initState() {
     super.initState();
-    navigation.current = Navigatable(Type.settingsSecurity);
+    _navigation.current = Navigatable(Type.settingsSecurity);
     _settingsSecurityBloc.listen((state) => _settingsSecurityStateChange(state));
   }
 
@@ -84,7 +82,6 @@ class _SettingsSecurityState extends State<SettingsSecurity> {
 
   void _settingsSecurityStateChange(SettingsSecurityState state) {
     if (state is SettingsSecurityStateLoading) {
-      _enableBack = false;
       String text;
       if (state.type == SettingsSecurityType.importKeys) {
         text = L10n.get(L.settingKeyImportRunning);
@@ -93,21 +90,16 @@ class _SettingsSecurityState extends State<SettingsSecurity> {
       } else if (state.type == SettingsSecurityType.initiateKeyTransfer) {
         text = L10n.get(L.settingKeyTransferRunning);
       }
-      _progressOverlayEntry = OverlayEntry(
-        builder: (context) => FullscreenProgress(
+      _progressOverlayEntry = FullscreenOverlay(
+        fullscreenProgress: FullscreenProgress(
           bloc: _settingsSecurityBloc,
           text: text,
           showProgressValues: false,
-          showCancelButton: false,
         ),
       );
       Overlay.of(context).insert(_progressOverlayEntry);
     } else if (state is SettingsSecurityStateSuccess || state is SettingsSecurityStateFailure) {
-      _enableBack = true;
-      if (_progressOverlayEntry != null) {
-        _progressOverlayEntry.remove();
-        _progressOverlayEntry = null;
-      }
+      _progressOverlayEntry?.remove();
       if (state is SettingsSecurityStateSuccess) {
         if (!isNullOrEmpty(state.setupCode)) {
           showNavigatableDialog(
@@ -122,13 +114,13 @@ class _SettingsSecurityState extends State<SettingsSecurity> {
                   onPressed: () {
                     var toastText = L10n.getFormatted(L.clipboardCopiedX, [L10n.get(L.code)]);
                     copyToClipboardWithToast(text: state.setupCode, toastText: toastText);
-                    navigation.pop(context);
+                    _navigation.pop(context);
                   },
                 ),
                 new FlatButton(
                   child: new Text(L10n.get(L.ok)),
                   onPressed: () {
-                    navigation.pop(context);
+                    _navigation.pop(context);
                   },
                 ),
               ],
@@ -155,7 +147,7 @@ class _SettingsSecurityState extends State<SettingsSecurity> {
   @override
   Widget build(BuildContext context) {
     return WillPopScope(
-      onWillPop: () async => _enableBack,
+      onWillPop: () async => _navigation.allowBackNavigation,
       child: Scaffold(
           appBar: AdaptiveAppBar(
             title: Text(L10n.get(L.security)),

--- a/lib/src/user/user_profile.dart
+++ b/lib/src/user/user_profile.dart
@@ -112,7 +112,7 @@ class _ProfileState extends State<UserProfile> {
   UserChangeBloc _userChangeBloc = UserChangeBloc();
   Navigation navigation = Navigation();
   InviteBloc _inviteBloc = InviteBloc();
-  OverlayEntry _fullScreenOverlayEntry;
+  OverlayEntry _progressOverlayEntry;
   String _avatarPath = "";
 
   @override
@@ -127,7 +127,7 @@ class _ProfileState extends State<UserProfile> {
     return BlocListener(
       bloc: _inviteBloc,
       listener: (context, state) {
-        _fullScreenOverlayEntry.remove();
+        _progressOverlayEntry?.remove();
       },
       child: BlocBuilder(
           bloc: _userBloc,
@@ -332,7 +332,7 @@ class _ProfileState extends State<UserProfile> {
     }
   }
 
-  void _changeTheme() async{
+  void _changeTheme() async {
     ThemeKey actualKey = CustomTheme.instanceOf(context).actualThemeKey;
     var newTheme = actualKey == ThemeKey.DARK ? ThemeKey.LIGHT : ThemeKey.DARK;
     await setPreference(preferenceAppThemeKey, newTheme.toString());
@@ -361,13 +361,13 @@ class _ProfileState extends State<UserProfile> {
   }
 
   createInviteUrl() {
-    _fullScreenOverlayEntry = OverlayEntry(
-      builder: (context) => FullscreenProgress(
+    _progressOverlayEntry = FullscreenOverlay(
+      fullscreenProgress: FullscreenProgress(
         bloc: _inviteBloc,
         text: L10n.get(L.pleaseWait),
       ),
     );
-    Overlay.of(context).insert(_fullScreenOverlayEntry);
+    Overlay.of(context).insert(_progressOverlayEntry);
     _inviteBloc.add(CreateInviteUrl());
   }
 }

--- a/lib/src/widgets/fullscreen_progress.dart
+++ b/lib/src/widgets/fullscreen_progress.dart
@@ -48,8 +48,26 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:ox_coi/src/base/bloc_progress_state.dart';
 import 'package:ox_coi/src/l10n/l.dart';
 import 'package:ox_coi/src/l10n/l10n.dart';
+import 'package:ox_coi/src/navigation/navigation.dart';
 import 'package:ox_coi/src/ui/custom_theme.dart';
 import 'package:ox_coi/src/ui/dimensions.dart';
+
+class FullscreenOverlay<T extends Bloc> extends OverlayEntry {
+  bool _isVisible = true;
+
+  FullscreenOverlay({FullscreenProgress fullscreenProgress}) : super(builder: (context) => fullscreenProgress) {
+    Navigation().allowBackNavigation = false;
+  }
+
+  @override
+  void remove() {
+    Navigation().allowBackNavigation = true;
+    if (_isVisible) {
+      _isVisible = false;
+      super.remove();
+    }
+  }
+}
 
 class FullscreenProgress<T extends Bloc> extends StatelessWidget {
   final String text;
@@ -75,45 +93,48 @@ class FullscreenProgress<T extends Bloc> extends StatelessWidget {
         if (state is ProgressState && state.progress != null) {
           progress = state.progress;
         }
-        return BackdropFilter(
-          filter: ImageFilter.blur(sigmaX: 10.0, sigmaY: 10.0),
-          child: Container(
-            padding: EdgeInsets.symmetric(horizontal: 16.0),
-            constraints: BoxConstraints.expand(),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.center,
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: <Widget>[
-                CircularProgressIndicator(
-                  valueColor: AlwaysStoppedAnimation<Color>(CustomTheme.of(context).onSurface),
-                ),
-                Padding(
-                  padding: EdgeInsets.only(top: verticalPadding),
-                  child: Center(
-                    child: Text(
-                      text,
-                      textAlign: TextAlign.center,
-                      style: Theme.of(context).textTheme.subhead.apply(color: CustomTheme.of(context).onSurface),
+        return GestureDetector(
+          behavior: HitTestBehavior.opaque,
+          child: BackdropFilter(
+            filter: ImageFilter.blur(sigmaX: 10.0, sigmaY: 10.0),
+            child: Container(
+              padding: EdgeInsets.symmetric(horizontal: 16.0),
+              constraints: BoxConstraints.expand(),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.center,
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: <Widget>[
+                  CircularProgressIndicator(
+                    valueColor: AlwaysStoppedAnimation<Color>(CustomTheme.of(context).onSurface),
+                  ),
+                  Padding(
+                    padding: EdgeInsets.only(top: verticalPadding),
+                    child: Center(
+                      child: Text(
+                        text,
+                        textAlign: TextAlign.center,
+                        style: Theme.of(context).textTheme.subhead.apply(color: CustomTheme.of(context).onSurface),
+                      ),
                     ),
                   ),
-                ),
-                if (showProgressValues)
-                  Padding(
-                    padding: EdgeInsets.only(top: verticalPaddingSmall),
-                    child: Text(
-                      buildDisplayableProgress(progress),
-                      textAlign: TextAlign.center,
-                      style: Theme.of(context).textTheme.subhead.apply(color: CustomTheme.of(context).onSurface),
+                  if (showProgressValues)
+                    Padding(
+                      padding: EdgeInsets.only(top: verticalPaddingSmall),
+                      child: Text(
+                        buildDisplayableProgress(progress),
+                        textAlign: TextAlign.center,
+                        style: Theme.of(context).textTheme.subhead.apply(color: CustomTheme.of(context).onSurface),
+                      ),
                     ),
-                  ),
-                if (showCancelButton)
-                  Padding(
-                    padding: EdgeInsets.only(top: verticalPaddingSmall),
-                    child: Container(
-                      child: RaisedButton(child: Text(L10n.get(L.cancel)), onPressed: cancelPressed),
-                    ),
-                  )
-              ],
+                  if (showCancelButton)
+                    Padding(
+                      padding: EdgeInsets.only(top: verticalPaddingSmall),
+                      child: Container(
+                        child: RaisedButton(child: Text(L10n.get(L.cancel)), onPressed: cancelPressed),
+                      ),
+                    )
+                ],
+              ),
             ),
           ),
         );


### PR DESCRIPTION
**Link to the given issue**
#405

**Describe what the problem was / what the new feature is**
Our progress overlay allowed tab, scroll and back actions during the progress.

**Describe your solution**
Capturing and dismissing all tap events. Added "back check" where required. 

**Additional context**

- Created a wrapper for the progress Widget (extends OverlayEntry) which automatically enables / disables back navigation
- Cleaned up the create / dismiss logic for overlays
- Global navigation state for back navigation added
