### PR TITLE
Extend build script to re-enable CI builds #415

### DIFF
--- a/lib/src/push/push_service.dart
+++ b/lib/src/push/push_service.dart
@@ -49,6 +49,7 @@ import 'package:ox_coi/src/data/push_resource.dart';
 import 'package:ox_coi/src/platform/preferences.dart';
 import 'package:ox_coi/src/utils/constants.dart';
 import 'package:ox_coi/src/utils/http.dart';
+import 'package:ox_coi/src/utils/text.dart';
 
 class PushService {
   static PushService _instance;
@@ -91,7 +92,7 @@ class PushService {
   }
 
   Future<String> getUrl() async {
-    var url = await getPreference(preferenceNotificationsPushServiceUrl);
+    String url = await getPreference(preferenceNotificationsPushServiceUrl);
     if (url.isNullOrEmpty()) {
       url = defaultCoiPushServiceUrl;
     }

--- a/lib/src/user/user_profile.dart
+++ b/lib/src/user/user_profile.dart
@@ -53,6 +53,7 @@ import 'package:ox_coi/src/l10n/l10n.dart';
 import 'package:ox_coi/src/main/root_child.dart';
 import 'package:ox_coi/src/navigation/navigatable.dart';
 import 'package:ox_coi/src/navigation/navigation.dart';
+import 'package:ox_coi/src/platform/app_information.dart';
 import 'package:ox_coi/src/platform/preferences.dart';
 import 'package:ox_coi/src/qr/qr.dart';
 import 'package:ox_coi/src/settings/settings_signature.dart';
@@ -266,6 +267,13 @@ class _ProfileState extends State<UserProfile> {
                       iconBackground: CustomTheme.of(context).bugReportIcon,
                       onTap: () => _settingsItemTapped(context, SettingsItemName.bugReport),
                     ),
+                    if (!isRelease())
+                      SettingsItem(
+                        icon: IconSource.bugReport,
+                        text: L10n.get(L.debug),
+                        iconBackground: CustomTheme.of(context).bugReportIcon,
+                        onTap: () => _settingsItemTapped(context, SettingsItemName.debug),
+                      ),
                   ],
                 ),
               ),
@@ -328,6 +336,9 @@ class _ProfileState extends State<UserProfile> {
         break;
       case SettingsItemName.bugReport:
         launch(issueUrl, forceSafariVC: false);
+        break;
+      case SettingsItemName.debug:
+        navigation.pushNamed(context, Navigation.settingsDebug);
         break;
     }
   }

--- a/lib/src/widgets/settings_item.dart
+++ b/lib/src/widgets/settings_item.dart
@@ -64,6 +64,7 @@ enum SettingsItemName {
   about,
   feedback,
   bugReport,
+  debug,
 }
 
 class SettingsItem extends StatelessWidget {

--- a/tools/build.triggerBuild.sh
+++ b/tools/build.triggerBuild.sh
@@ -19,6 +19,7 @@ IOS_BUILD_FOLDER="build/app/outputs/ios/${flavor}"
 
 ANDROID_ARM_32="armeabi-v7a_libnative-utils.so"
 ANDROID_ARM_64="arm64-v8a_libnative-utils.so"
+ANDROID_X86="x86_libnative-utils.so"
 ANDROID_X64="x86_64_libnative-utils.so"
 ANDROID_LIBRARY_FOLDER="android/libs"
 ANDROID_LIBRARY_FILENAME="libnative-utils.so"
@@ -136,10 +137,12 @@ function downloadCore {
         if [[ ${coreVersion} == "latest" ]]; then
             wgetQuiet "${urlLatest}${ANDROID_ARM_32}";
             wgetQuiet "${urlLatest}${ANDROID_ARM_64}";
+            wgetQuiet "${urlLatest}${ANDROID_X86}";
             wgetQuiet "${urlLatest}${ANDROID_X64}";
         else
             wgetQuiet "${urlTag}${ANDROID_ARM_32}";
             wgetQuiet "${urlTag}${ANDROID_ARM_64}";
+            wgetQuiet "${urlTag}${ANDROID_X86}";
             wgetQuiet "${urlTag}${ANDROID_X64}";
         fi
     elif isIos; then
@@ -174,6 +177,7 @@ function moveCore {
     if isAndroid; then
         moveSingleCoreFile ${ANDROID_ARM_32}
         moveSingleCoreFile ${ANDROID_ARM_64}
+        moveSingleCoreFile ${ANDROID_X86}
         moveSingleCoreFile ${ANDROID_X64}
     elif isIos; then
         moveSingleCoreFile ${IOS_LIBRARY_FILENAME}

--- a/tools/build.triggerBuild.sh
+++ b/tools/build.triggerBuild.sh
@@ -9,6 +9,7 @@ mode=$2
 flavor=$3
 buildName=$4
 buildNumber=$5
+coreVersion=$6
 
 # Constants
 SCRIPT_BASEDIR=$(dirname "$0")
@@ -16,8 +17,15 @@ PLUGIN_FOLDER="flutter-deltachat-core";
 CORE_BUILD_SCRIPT="./build-dcc.sh"
 IOS_BUILD_FOLDER="build/app/outputs/ios/${flavor}"
 
+ANDROID_ARM_32="armeabi-v7a_libnative-utils.so"
+ANDROID_ARM_64="arm64-v8a_libnative-utils.so"
+ANDROID_X86="x86_libnative-utils.so"
+ANDROID_X64="x86_64_libnative-utils.so"
+ANDROID_LIBRARY_FOLDER="android/libs"
+ANDROID_LIBRARY_FILENAME="libnative-utils.so"
+
 # Setup
-if [[ "$#" != 5 ]]; then
+if [[ "$#" != 6 ]]; then
     echo "Usage of $0:"
     echo
     echo "1. parameter:     Platform [android, ios, all]"
@@ -25,13 +33,19 @@ if [[ "$#" != 5 ]]; then
     echo "3. parameter:     Flavor [development, stable]"
     echo "4. parameter:     Build name (semantic versioning required)"
     echo "5. parameter:     Build number (integer)"
+    echo "6. parameter:     Core version [local, latest, 'Github tag']"
     echo
-    echo "Example android:  ./build.triggerBuild.sh android release stable 0.450.1 415"
-    echo "Example iOS:      ./build.triggerBuild.sh ios release stable 0.450.1 415"
+    echo "Example android:  ./build.triggerBuild.sh android release stable 0.450.1 415 local"
+    echo "Example iOS:      ./build.triggerBuild.sh ios release stable 0.450.1 415 local"
     exit 0
 fi
 
 # Functions
+function error {
+    echo >&2 $1
+    exit $2
+}
+
 function isAndroid {
     if [[ ${platforms} == "android" || ${platforms} == "all" ]]; then
         true
@@ -55,7 +69,15 @@ function isRelease {
         false
     fi
 }
-#flutter build apk --build-name=${BUILD_NAME} --build-number=${CI_PIPELINE_ID} --flavor development --debug
+
+function isLocalDcc {
+    if [[ ${coreVersion} == "local" ]]; then
+        true
+    else
+        false
+    fi
+}
+
 function androidDebugBuild {
     echo "Android debug build for ${flavor} started"
     flutter build apk --build-name=${buildName} --build-number=${buildNumber} --flavor ${flavor} --debug
@@ -80,11 +102,9 @@ function iosReleaseBuild {
     xcodebuild -exportArchive -archivePath "${IOS_BUILD_FOLDER}/Runner.xcarchive" -exportOptionsPlist ios/exportOptions${flavor}.plist -exportPath "${IOS_BUILD_FOLDER}/Runner.ipa" -allowProvisioningUpdates
 }
 
-function getCore {
+function checkoutCore {
     if [[ -d "$PLUGIN_FOLDER" ]]; then
-        cd ${PLUGIN_FOLDER}
-        git pull
-        git submodule update
+        echo "Plugin repository found, using the current state. To ensure the latest plugin + DCC is used, please execute 'git pull && git submodule update' in the plugin repository"
     else
         git clone --recurse-submodules https://github.com/open-xchange/flutter-deltachat-core.git
     fi
@@ -98,19 +118,73 @@ function buildCore {
             ${CORE_BUILD_SCRIPT} ios | sed 's/^/    /'
         fi
      else
-        exit 2
+        error "Core script is missing" 2
      fi
+}
+
+function wgetQuiet {
+    wget -q --show-progress $1
+}
+
+function downloadCore {
+    urlLatest="https://github.com/open-xchange/flutter-deltachat-core/releases/latest/download/"
+    urlTag="https://github.com/open-xchange/flutter-deltachat-core/releases/download/${coreVersion}/"
+
+    if isAndroid; then
+        if [[ ${coreVersion} == "latest" ]]; then
+            wgetQuiet "${urlLatest}${ANDROID_ARM_32}";
+            wgetQuiet "${urlLatest}${ANDROID_ARM_64}";
+            wgetQuiet "${urlLatest}${ANDROID_X86}";
+            wgetQuiet "${urlLatest}${ANDROID_X64}";
+        else
+            wgetQuiet "${urlTag}${ANDROID_ARM_32}";
+            wgetQuiet "${urlTag}${ANDROID_ARM_64}";
+            wgetQuiet "${urlTag}${ANDROID_X86}";
+            wgetQuiet "${urlTag}${ANDROID_X64}";
+        fi
+    fi
+}
+
+function moveSingleCoreFile {
+    if isAndroid; then
+        folder=$(sed "s/_$ANDROID_LIBRARY_FILENAME//g" <<< $1)
+        targetFolder="../${PLUGIN_FOLDER}/${ANDROID_LIBRARY_FOLDER}/${folder}/"
+        targetPath="${targetFolder}${ANDROID_LIBRARY_FILENAME}"
+        mkdir -p ${targetFolder}
+        rm -f ${targetPath}
+        echo "Moving $1 to ${targetPath}"
+        mv ${1} ${targetPath}
+    fi
+}
+
+function moveCore {
+    if isAndroid; then
+        moveSingleCoreFile ${ANDROID_ARM_32}
+        moveSingleCoreFile ${ANDROID_ARM_64}
+        moveSingleCoreFile ${ANDROID_X86}
+        moveSingleCoreFile ${ANDROID_X64}
+    fi
 }
 
 # Execution
 echo "-- Setup --"
-cd ${SCRIPT_BASEDIR}/.. || error 1
-echo "Building / updating core"
-(
-    cd .. || error 3
-    getCore
-    buildCore
-)
+cd ${SCRIPT_BASEDIR}/.. || error "Can't navigate into app directory" 1
+if isLocalDcc; then
+    echo "Building / updating core"
+    (
+        cd .. || error "Can't navigate into parent directory" 3
+        checkoutCore
+        cd ${PLUGIN_FOLDER} || error "Can't navigate into plugin directory" 4
+        buildCore
+    )
+else
+    echo "Downloading core"
+    (
+        downloadCore
+        echo "Moving core"
+        moveCore
+    )
+fi
 echo "-- Building --"
 if isAndroid; then
     if isRelease; then

--- a/tools/build.triggerBuild.sh
+++ b/tools/build.triggerBuild.sh
@@ -162,6 +162,9 @@ function moveSingleCoreFile {
         mv ${1} ${targetPath}
     elif isIos; then
         targetFolder="../${PLUGIN_FOLDER}/${IOS_LIBRARY_FOLDER}/"
+        targetPath="${targetFolder}${IOS_LIBRARY_FILENAME}"
+        mkdir -p ${targetFolder}
+        rm -f ${targetPath}
         echo "Moving $1 to ${targetFolder}"
         mv ${1} ${targetFolder}
     fi
@@ -213,7 +216,7 @@ fi
 echo "-- Performing additional build steps --"
 if isIos; then
     echo "Adjusting symlinks"
-    cd "..$PLUGIN_FOLDER/$IOS_LIBRARY_FOLDER"
+    cd "../$PLUGIN_FOLDER/$IOS_LIBRARY_FOLDER"
     ln -sf "../../delta_chat_core/deltachat-ffi/deltachat.h" .
 fi
 echo "-- Finishing --"


### PR DESCRIPTION
**Link to the given issue**
#415 

**Describe what the problem was / what the new feature is**
We weren't able to build the app without a Rust tool chain.

**Describe your solution**
Added the possibility to use pre-compiled DCC binaries in the build script. Those are provided by the flutter-deltachat-core plugin releases. A local build is still possible. Executing the script will also allow developers without Rust tool chain to develop the app. The given changes allow easier CI builds.

**Additional context**
- Re-enabled the debug setting in the app
- Fixed a "null checking" bug during push registration
- @CihanOezkan we need to add a few lines to also support iOS with downloaded DCC binaries. Please just add another commit on this branch.
