### PR TITLE
Improve voice recording UX #257

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -13,6 +13,8 @@
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.CAMERA" />
 
+    <uses-permission android:name="android.permission.VIBRATE" />
+
     <application
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"

--- a/lib/src/adaptiveWidgets/adaptive_icon.dart
+++ b/lib/src/adaptiveWidgets/adaptive_icon.dart
@@ -108,6 +108,8 @@ enum IconSource {
   signature,
   serverSetting,
   feedback,
+  openLock,
+  stopPlay,
   iosChevron,
 }
 
@@ -174,6 +176,8 @@ const iconData = {
   IconSource.signature: Icons.gesture,
   IconSource.serverSetting: Icons.router,
   IconSource.feedback: Icons.feedback,
+  IconSource.openLock : Icons.lock_open,
+  IconSource.stopPlay : Icons.stop,
   IconSource.iosChevron: CupertinoIcons.right_chevron,
 };
 

--- a/lib/src/chat/chat.dart
+++ b/lib/src/chat/chat.dart
@@ -270,8 +270,8 @@ class _ChatState extends State<Chat> with ChatComposer, ChatCreateMixin, InviteM
   _clearAudioComposer() async {
     await Future.delayed(Duration(microseconds: 100));
     setState(() {
+      _dbPeakList.clear();
       _composingAudioTimer = null;
-      _dbPeakList = null;
       _isStopped = false;
       _isLocked = false;
       _isPlaying = false;
@@ -694,6 +694,7 @@ class _ChatState extends State<Chat> with ChatComposer, ChatCreateMixin, InviteM
       _messageListBloc.add(SendMessage(text: text));
     } else {
       int type = getType();
+      if(type == ChatMsg.typeVoice) _onAudioRecordingAbort();
       _messageListBloc.add(SendMessage(path: _filePath, fileType: type, text: text, isShared: widget.sharedData != null));
     }
 

--- a/lib/src/chat/chat.dart
+++ b/lib/src/chat/chat.dart
@@ -50,6 +50,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:ox_coi/src/adaptiveWidgets/adaptive_app_bar.dart';
 import 'package:ox_coi/src/adaptiveWidgets/adaptive_icon.dart';
 import 'package:ox_coi/src/adaptiveWidgets/adaptive_icon_button.dart';
+import 'package:ox_coi/src/adaptiveWidgets/adaptive_superellipse_icon.dart';
 import 'package:ox_coi/src/chat/chat_bloc.dart';
 import 'package:ox_coi/src/chat/chat_change_bloc.dart';
 import 'package:ox_coi/src/chat/chat_change_event_state.dart';
@@ -79,6 +80,7 @@ import 'package:ox_coi/src/ui/custom_theme.dart';
 import 'package:ox_coi/src/ui/dimensions.dart';
 import 'package:ox_coi/src/ui/strings.dart';
 import 'package:ox_coi/src/utils/dialog_builder.dart';
+import 'package:ox_coi/src/utils/image.dart';
 import 'package:ox_coi/src/utils/keyMapping.dart';
 import 'package:ox_coi/src/utils/key_generator.dart';
 import 'package:ox_coi/src/utils/toast.dart';
@@ -117,7 +119,12 @@ class _ChatState extends State<Chat> with ChatComposer, ChatCreateMixin, InviteM
 
   final TextEditingController _textController = new TextEditingController();
   bool _isComposingText = false;
+  bool _isLocked = false;
+  bool _isStopped = false;
+  bool _isPlaying = false;
   String _composingAudioTimer;
+  List<double> _dbPeakList;
+  int _replayTime = 0;
   String _filePath = "";
   int _knownType;
   FileType _selectedFileType;
@@ -203,14 +210,34 @@ class _ChatState extends State<Chat> with ChatComposer, ChatCreateMixin, InviteM
       setState(() {
         _composingAudioTimer = state.timer;
       });
+    } else if (state is ChatComposerDBPeakUpdated) {
+      setState(() {
+        _dbPeakList = state.dbPeakList;
+      });
     } else if (state is ChatComposerRecordingAudioStopped) {
-      if (state.filePath != null && state.shouldSend) {
+      if (state.filePath != null) {
         _filePath = state.filePath;
         _knownType = ChatMsg.typeVoice;
-        _onPrepareMessageSend();
       }
       setState(() {
-        _composingAudioTimer = null;
+        _dbPeakList = state.dbPeakList;
+        _isStopped = true;
+      });
+
+      if (state.sendAudio) {
+        _onPrepareMessageSend();
+      }
+    } else if (state is ChatComposerRecordingAudioAborted) {
+      _clearAudioComposer();
+    } else if (state is ChatComposerReplayStopped) {
+      setState(() {
+        _isPlaying = false;
+        _replayTime = 0;
+      });
+    } else if (state is ChatComposerReplayTimeUpdated) {
+      setState(() {
+        _dbPeakList = state.dbPeakList;
+        _replayTime = state.replayTime;
       });
     } else if (state is ChatComposerRecordingImageOrVideoStopped) {
       if (state.type != 0 && state.filePath != null) {
@@ -218,16 +245,29 @@ class _ChatState extends State<Chat> with ChatComposer, ChatCreateMixin, InviteM
         _knownType = state.type;
         _onPrepareMessageSend();
       }
-    } else if (state is ChatComposerRecordingAborted) {
+    } else if (state is ChatComposerRecordingFailed) {
       _composingAudioTimer = null;
-      String chatComposeAborted;
+      _dbPeakList = null;
+      String chatComposeFailed;
       if (state.error == ChatComposerStateError.missingMicrophonePermission) {
-        chatComposeAborted = L10n.get(L.chatAudioRecordingFailed);
+        chatComposeFailed = L10n.get(L.chatAudioRecordingFailed);
       } else if (state.error == ChatComposerStateError.missingCameraPermission) {
-        chatComposeAborted = L10n.get(L.chatVideoRecordingFailed);
+        chatComposeFailed = L10n.get(L.chatVideoRecordingFailed);
       }
-      showToast(chatComposeAborted);
+      showToast(chatComposeFailed);
     }
+  }
+
+  _clearAudioComposer() async {
+    await Future.delayed(Duration(microseconds: 100));
+    setState(() {
+      _composingAudioTimer = null;
+      _dbPeakList = null;
+      _isStopped = false;
+      _isLocked = false;
+      _isPlaying = false;
+      _replayTime = 0;
+    });
   }
 
   @override
@@ -298,29 +338,55 @@ class _ChatState extends State<Chat> with ChatComposer, ChatCreateMixin, InviteM
                 ),
               ],
             ),
-            body: new Column(
+            body: Stack(
               children: <Widget>[
-                new Flexible(
-                  child: MultiBlocProvider(
-                    providers: [
-                      BlocProvider<MessageListBloc>.value(
-                        value: _messageListBloc,
+                Column(
+                  children: <Widget>[
+                    Flexible(
+                      child: MultiBlocProvider(
+                        providers: [
+                          BlocProvider<MessageListBloc>.value(
+                            value: _messageListBloc,
+                          ),
+                          BlocProvider<ChatBloc>.value(
+                            value: _chatBloc,
+                          ),
+                        ],
+                        child: MessageList(scrollController: _scrollController, chatId: widget.chatId),
                       ),
-                      BlocProvider<ChatBloc>.value(
-                        value: _chatBloc,
+                    ),
+                    if (isInviteChat(widget.chatId)) buildInviteChoice(),
+                    if (_filePath.isNotEmpty && _knownType != ChatMsg.typeVoice) buildPreview(),
+                    Divider(height: dividerHeight),
+                    if (state is ChatStateSuccess && !state.isRemoved)
+                      Container(
+                        decoration: BoxDecoration(color: CustomTheme.of(context).surface),
+                        child: SafeArea(child: _buildTextComposer()),
                       ),
-                    ],
-                    child: MessageList(scrollController: _scrollController, chatId: widget.chatId),
-                  ),
+                  ],
                 ),
-                if (isInviteChat(widget.chatId)) buildInviteChoice(),
-                if (_filePath.isNotEmpty) buildPreview(),
-                Divider(height: dividerHeight),
-                if (state is ChatStateSuccess && !state.isRemoved)
-                  new Container(
-                    decoration: new BoxDecoration(color: CustomTheme.of(context).surface),
-                    child: SafeArea(child: _buildTextComposer()),
+                Visibility(
+                  visible: _composingAudioTimer != null,
+                  child: Positioned(
+                    bottom: 72.0,
+                    right: 8.0,
+                    child: Container(
+                      decoration: ShapeDecoration(
+                        shape: getSuperEllipseShape(32.0),
+                        color: CustomTheme.of(context).surface,
+                      ),
+                      child: AdaptiveIconButton(
+                        icon: AdaptiveSuperellipseIcon(
+                          icon: IconSource.send,
+                          iconSize: 20.0,
+                          color: CustomTheme.of(context).accent,
+                          iconColor: CustomTheme.of(context).white,
+                        ),
+                        onPressed: () => _isLocked ? _chatComposerBloc.add(StopAudioRecording(sendAudio: true)) : _onPrepareMessageSend(),
+                      ),
+                    ),
                   ),
+                )
               ],
             ),
           );
@@ -500,34 +566,63 @@ class _ChatState extends State<Chat> with ChatComposer, ChatCreateMixin, InviteM
 
   Widget _buildTextComposer() {
     final List<Widget> widgets = List();
-    widgets.add(buildLeftComposerPart(
-      context: context,
-      type: _getComposerType(),
-      onShowAttachmentChooser: _showAttachmentChooser,
-      onAudioRecordingAbort: _onAudioRecordingAbort,
-    ));
+    if (_getComposerType() != ComposerModeType.isVoiceRecording) {
+      widgets.add(buildLeftComposerPart(
+        context: context,
+        type: _getComposerType(),
+        onShowAttachmentChooser: _showAttachmentChooser,
+        onAudioRecordingAbort: _onAudioRecordingAbort,
+      ));
+    } else if (_isLocked || _isStopped) {
+      widgets.add(buildLeftComposerPart(
+        context: context,
+        type: _getComposerType(),
+        onShowAttachmentChooser: _showAttachmentChooser,
+        onAudioRecordingAbort: _onAudioRecordingAbort,
+      ));
+    } else {
+      widgets.add(Padding(
+        padding: EdgeInsets.only(left: 48.0),
+      ));
+    }
     widgets.add(buildCenterComposerPart(
       context: context,
       type: _getComposerType(),
       textController: _textController,
       onTextChanged: _onInputTextChanged,
-      text: _composingAudioTimer,
+      dbPeakList: _dbPeakList,
+      replayTime: _replayTime,
+      isStopped: _isStopped,
+      isPlaying: _isPlaying,
     ));
     widgets.addAll(buildRightComposerPart(
       context: context,
       onRecordAudioPressed: _onRecordAudioPressed,
+      onRecordAudioStopped: _onAudioRecordingStopped,
+      onRecordAudioStoppedLongPress: _onAudioRecordingStoppedLongPress,
+      onRecordAudioLocked: _onAudioRecordingLocked,
+      onAudioPlaying: _onAudioPlaying,
+      onAudioPlayingStopped: _onAudioPlayingStopped,
       onRecordVideoPressed: _onRecordVideoPressed,
       onCaptureImagePressed: _onCaptureImagePressed,
       type: _getComposerType(),
       onSendText: _onPrepareMessageSend,
+      text: _composingAudioTimer,
+      isLocked: _isLocked,
+      isStopped: _isStopped,
+      isPlaying: _isPlaying,
     ));
 
     return IconTheme(
       data: IconThemeData(color: CustomTheme.of(context).accent),
       child: Container(
+        height: 60.0,
         margin: const EdgeInsets.symmetric(horizontal: composerHorizontalPadding),
-        child: Row(
-          children: widgets,
+        child: BlocProvider.value(
+          value: _chatComposerBloc,
+          child: Row(
+            children: widgets,
+          ),
         ),
       ),
     );
@@ -593,6 +688,7 @@ class _ChatState extends State<Chat> with ChatComposer, ChatCreateMixin, InviteM
     }
 
     _closePreview();
+    _clearAudioComposer();
     setState(() {
       _knownType = null;
       _isComposingText = false;
@@ -629,16 +725,61 @@ class _ChatState extends State<Chat> with ChatComposer, ChatCreateMixin, InviteM
     return type;
   }
 
-  _onRecordAudioPressed() async {
-    if (ComposerModeType.isVoiceRecording != _getComposerType()) {
-      _chatComposerBloc.add(StartAudioRecording());
+  double startLongPressDx;
+  double startLongPressDy;
+
+  _onRecordAudioPressed(LongPressStartDetails details) {
+    startLongPressDx = details.localPosition.dx;
+    startLongPressDy = details.localPosition.dy;
+    _chatComposerBloc.add(StartAudioRecording());
+    setState(() {
+      _isStopped = false;
+      _isPlaying = false;
+    });
+  }
+
+  _onAudioRecordingStoppedLongPress(LongPressEndDetails details) {
+    double dxDifference = startLongPressDx - details.localPosition.dx;
+    double dyDifference = startLongPressDy - details.localPosition.dy;
+
+    if (dyDifference > 50.0) {
+      _chatComposerBloc.add(StopAudioRecording(sendAudio: true));
+    } else if (dxDifference > 45.0) {
+      setState(() {
+        _isLocked = true;
+      });
     } else {
-      _chatComposerBloc.add(StopAudioRecording(shouldSend: true));
+      _chatComposerBloc.add(StopAudioRecording());
     }
   }
 
+  _onAudioRecordingStopped() {
+    _chatComposerBloc.add(StopAudioRecording());
+  }
+
+  _onAudioRecordingLocked() {
+    setState(() {
+      _isLocked = true;
+    });
+  }
+
+  _onAudioPlaying() {
+    setState(() {
+      _isPlaying = true;
+    });
+    _chatComposerBloc.add(ReplayAudio());
+  }
+
+  _onAudioPlayingStopped() {
+    setState(() {
+      _replayTime = 0;
+      _isPlaying = false;
+    });
+    _chatComposerBloc.add(StopAudioReplay());
+  }
+
   _onAudioRecordingAbort() {
-    _chatComposerBloc.add(StopAudioRecording(shouldSend: false));
+    _chatComposerBloc.add(AbortAudioRecording());
   }
 
   _onCaptureImagePressed() {
@@ -783,7 +924,7 @@ class MessageList extends StatelessWidget {
           if (state.messageIds.length > 0) {
             return ListView.custom(
               controller: scrollController,
-              padding: new EdgeInsets.all(8.0),
+              padding: const EdgeInsets.fromLTRB(messageListPadding, messageListPadding, messageListPadding, composerMessagePadding),
               reverse: true,
               childrenDelegate: SliverChildBuilderDelegate(
                   (BuildContext context, int index) {

--- a/lib/src/chat/chat_composer_bloc.dart
+++ b/lib/src/chat/chat_composer_bloc.dart
@@ -54,8 +54,15 @@ import 'package:permission_handler/permission_handler.dart';
 
 class ChatComposerBloc extends Bloc<ChatComposerEvent, ChatComposerState> {
   StreamSubscription<RecordStatus> _recorderSubscription;
+  StreamSubscription<double> _recorderDBPeakSubscription;
+  StreamSubscription<PlayStatus> _playerSubscription;
   FlutterSound _flutterSound = FlutterSound();
   String _audioPath;
+  bool _removeFirstEntry;
+  int _cutoffValue;
+  int _replayTime;
+  bool _isSeeking;
+  List<double> _dbPeakList = List<double>();
 
   @override
   ChatComposerState get initialState => ChatComposerInitial();
@@ -64,59 +71,140 @@ class ChatComposerBloc extends Bloc<ChatComposerEvent, ChatComposerState> {
   Stream<ChatComposerState> mapEventToState(ChatComposerEvent event) async* {
     if (event is StartAudioRecording) {
       try {
+        _removeFirstEntry = false;
+        _cutoffValue = 1;
+        _replayTime = 0;
+        _isSeeking = false;
+        _dbPeakList = List<double>();
         bool hasContactPermission = await hasPermission(PermissionGroup.microphone);
         bool hasFilesPermission = await hasPermission(PermissionGroup.storage);
         if (hasContactPermission && hasFilesPermission) {
           await startAudioRecorder();
-          yield ChatComposerRecordingAudio(timer: "00:00:00");
+          yield ChatComposerRecordingAudio(timer: "00:00");
         } else {
-          yield ChatComposerRecordingAborted(error: ChatComposerStateError.missingMicrophonePermission);
+          yield ChatComposerRecordingFailed(error: ChatComposerStateError.missingMicrophonePermission);
         }
       } catch (err) {
         print('startRecorder error: $err');
-        yield ChatComposerRecordingAudioStopped(filePath: null, shouldSend: false);
+        yield ChatComposerRecordingAudioStopped(filePath: null, dbPeakList: null, sendAudio: false);
       }
     } else if (event is UpdateAudioRecording) {
       yield ChatComposerRecordingAudio(timer: event.timer);
+    } else if (event is UpdateAudioDBPeak) {
+      yield ChatComposerDBPeakUpdated(dbPeakList: event.dbPeakList);
+    } else if (event is RemoveFirstAudioDBPeak) {
+      if (_removeFirstEntry != event.removeFirstEntry) {
+        _removeFirstEntry = event.removeFirstEntry;
+      }
+      _cutoffValue = event.cutoffValue;
     } else if (event is StopAudioRecording) {
-      stopAudioRecorder(event.shouldSend);
-    } else if (event is AudioRecordingStopped) {
-      yield ChatComposerRecordingAudioStopped(filePath: _audioPath, shouldSend: event.shouldSend);
+      yield* stopAudioRecorder(sendAudio: event.sendAudio);
+    } else if (event is AbortAudioRecording) {
+      yield* stopAudioRecorder(isAborted: true);
     } else if (event is StartImageOrVideoRecording) {
       bool hasCameraPermission = await hasPermission(PermissionGroup.camera);
       if (hasCameraPermission) {
         startImageOrVideoRecorder(event.pickImage);
       } else {
-        yield ChatComposerRecordingAborted(error: ChatComposerStateError.missingCameraPermission);
+        yield ChatComposerRecordingFailed(error: ChatComposerStateError.missingCameraPermission);
       }
     } else if (event is StopImageOrVideoRecording) {
       if (!_wasImageOrVideoRecordingCanceled(event.filePath, event.type)) {
         yield ChatComposerRecordingImageOrVideoStopped(filePath: event.filePath, type: event.type);
       }
+    } else if (event is ReplayAudio) {
+      _replayAudio();
+    } else if (event is ReplayAudioStopped) {
+      yield ChatComposerReplayStopped();
+    } else if (event is ReplayAudioTimeUpdate) {
+      yield ChatComposerReplayTimeUpdated(dbPeakList: _dbPeakList, replayTime: event.replayTime);
+    } else if (event is ReplayAudioSeek) {
+      _seekAudioPlayer(event.seekValue);
+    } else if (event is UpdateReplayTime) {
+      _isSeeking = true;
+      _replayTime = event.replayTime;
+      yield ChatComposerReplayTimeUpdated(dbPeakList: _dbPeakList, replayTime: _replayTime);
+    } else if (event is StopAudioReplay) {
+      _stopAudio();
     }
   }
 
   Future<void> startAudioRecorder() async {
+    _dbPeakList = List<double>();
+    final shortPeakList = List<double>();
     _audioPath = await _flutterSound.startRecorder(null, bitRate: 64000, numChannels: 1);
+    _flutterSound.setDbLevelEnabled(true);
+    _flutterSound.setDbPeakLevelUpdate(1.0);
+    _recorderDBPeakSubscription = _flutterSound.onRecorderDbPeakChanged.listen((newDBPeak) {
+      var newPeak = (newDBPeak / 5);
+      _dbPeakList.add(newPeak);
+      shortPeakList.add((newPeak));
+      if (_removeFirstEntry) {
+        shortPeakList.removeRange(0, _cutoffValue);
+      }
+      add(UpdateAudioDBPeak(dbPeakList: shortPeakList));
+    });
     _recorderSubscription = _flutterSound.onRecorderStateChanged.listen((e) {
-      print("coezkan: ${e.currentPosition}");
       String timer = getTimerFromTimestamp(e.currentPosition.toInt());
       add(UpdateAudioRecording(timer: timer));
     });
   }
 
-  void stopAudioRecorder(bool shouldSend) async {
+  _seekAudioPlayer(int seekValue) async {
+    _isSeeking = false;
+    _replayTime = seekValue;
+    add(ReplayAudioTimeUpdate(replayTime: _replayTime));
+    int milliSeconds = (seekValue * 1000);
+    await _flutterSound.seekToPlayer(milliSeconds);
+  }
+
+  _replayAudio() async {
+    await _flutterSound.startPlayer(_audioPath);
+    _replayTime = 0;
+    _playerSubscription = _flutterSound.onPlayerStateChanged.listen((data) {
+      if (data?.duration != data?.currentPosition) {
+        int currentTimer = (data.currentPosition / 1000).round();
+        if (currentTimer > _replayTime && _replayTime <= _dbPeakList.length && !_isSeeking) {
+          _replayTime = currentTimer;
+          add(ReplayAudioTimeUpdate(replayTime: _replayTime));
+        }
+      } else {
+        add(ReplayAudioStopped());
+      }
+    });
+  }
+
+  _stopAudio() async {
+    await _flutterSound.stopPlayer();
+    _isSeeking = false;
+    if (_playerSubscription != null) {
+      _playerSubscription.cancel();
+      _playerSubscription = null;
+    }
+  }
+
+  Stream<ChatComposerState> stopAudioRecorder({bool isAborted = false, bool sendAudio}) async* {
     try {
       String result = await _flutterSound.stopRecorder();
       print('stopRecorder: $result');
 
       if (_recorderSubscription != null) {
         _recorderSubscription.cancel();
+        _recorderSubscription = null;
+      }
+      if (_recorderDBPeakSubscription != null) {
+        _recorderDBPeakSubscription.cancel();
+        _recorderDBPeakSubscription = null;
       }
     } catch (err) {
       print('stopRecorder error: $err');
     }
-    add(AudioRecordingStopped(audioPath: _audioPath, shouldSend: shouldSend));
+
+    if (isAborted) {
+      yield ChatComposerRecordingAudioAborted();
+    } else {
+      yield ChatComposerRecordingAudioStopped(filePath: _audioPath, dbPeakList: _dbPeakList, sendAudio: sendAudio);
+    }
   }
 
   Future<void> startImageOrVideoRecorder(bool pickImage) async {

--- a/lib/src/chat/chat_composer_bloc.dart
+++ b/lib/src/chat/chat_composer_bloc.dart
@@ -216,6 +216,9 @@ class ChatComposerBloc extends Bloc<ChatComposerEvent, ChatComposerState> {
     }
 
     if (isAborted) {
+      if(_flutterSound.isPlaying){
+        await _flutterSound.stopPlayer();
+      }
       yield ChatComposerRecordingAudioAborted();
     } else {
       yield ChatComposerRecordingAudioStopped(filePath: _audioPath, dbPeakList: _dbPeakList, sendAudio: sendAudio);

--- a/lib/src/chat/chat_composer_event_state.dart
+++ b/lib/src/chat/chat_composer_event_state.dart
@@ -46,6 +46,8 @@ abstract class ChatComposerEvent {}
 
 class StartAudioRecording extends ChatComposerEvent {}
 
+class CheckPermissions extends ChatComposerEvent {}
+
 class UpdateAudioRecording extends ChatComposerEvent {
   final String timer;
 
@@ -118,6 +120,8 @@ enum ChatComposerStateError {
 abstract class ChatComposerState {}
 
 class ChatComposerInitial extends ChatComposerState {}
+
+class ChatComposerPermissionsAccepted extends ChatComposerState {}
 
 class ChatComposerRecordingAudio extends ChatComposerState {
   String timer;

--- a/lib/src/chat/chat_composer_event_state.dart
+++ b/lib/src/chat/chat_composer_event_state.dart
@@ -52,18 +52,26 @@ class UpdateAudioRecording extends ChatComposerEvent {
   UpdateAudioRecording({@required this.timer});
 }
 
+class UpdateAudioDBPeak extends ChatComposerEvent {
+  final List<double> dbPeakList;
+
+  UpdateAudioDBPeak({@required this.dbPeakList});
+}
+
+class RemoveFirstAudioDBPeak extends ChatComposerEvent {
+  final bool removeFirstEntry;
+  final int cutoffValue;
+
+  RemoveFirstAudioDBPeak({@required this.removeFirstEntry, @required this.cutoffValue});
+}
+
 class StopAudioRecording extends ChatComposerEvent {
-  final bool shouldSend;
+  final bool sendAudio;
 
-  StopAudioRecording({@required this.shouldSend});
+  StopAudioRecording({this.sendAudio = false});
 }
 
-class AudioRecordingStopped extends ChatComposerEvent {
-  final String audioPath;
-  final bool shouldSend;
-
-  AudioRecordingStopped({@required this.audioPath, @required this.shouldSend});
-}
+class AbortAudioRecording extends ChatComposerEvent {}
 
 class StartImageOrVideoRecording extends ChatComposerEvent {
   final bool pickImage;
@@ -76,6 +84,30 @@ class StopImageOrVideoRecording extends ChatComposerEvent {
   final int type;
 
   StopImageOrVideoRecording({@required this.type, @required this.filePath});
+}
+
+class ReplayAudio extends ChatComposerEvent {}
+
+class ReplayAudioTimeUpdate extends ChatComposerEvent {
+  final int replayTime;
+
+  ReplayAudioTimeUpdate({@required this.replayTime});
+}
+
+class ReplayAudioStopped extends ChatComposerEvent {}
+
+class StopAudioReplay extends ChatComposerEvent {}
+
+class ReplayAudioSeek extends ChatComposerEvent {
+  final int seekValue;
+
+  ReplayAudioSeek({@required this.seekValue});
+}
+
+class UpdateReplayTime extends ChatComposerEvent {
+  final int replayTime;
+
+  UpdateReplayTime({@required this.replayTime});
 }
 
 enum ChatComposerStateError {
@@ -93,17 +125,35 @@ class ChatComposerRecordingAudio extends ChatComposerState {
   ChatComposerRecordingAudio({@required this.timer});
 }
 
-class ChatComposerRecordingAudioStopped extends ChatComposerState {
-  String filePath;
-  bool shouldSend;
+class ChatComposerDBPeakUpdated extends ChatComposerState {
+  List<double> dbPeakList;
 
-  ChatComposerRecordingAudioStopped({@required this.filePath, @required this.shouldSend});
+  ChatComposerDBPeakUpdated({@required this.dbPeakList});
 }
 
-class ChatComposerRecordingAborted extends ChatComposerState {
+class ChatComposerRecordingAudioStopped extends ChatComposerState {
+  String filePath;
+  List<double> dbPeakList;
+  bool sendAudio;
+
+  ChatComposerRecordingAudioStopped({@required this.filePath, @required this.dbPeakList, @required this.sendAudio});
+}
+
+class ChatComposerRecordingAudioAborted extends ChatComposerState {}
+
+class ChatComposerRecordingFailed extends ChatComposerState {
   ChatComposerStateError error;
 
-  ChatComposerRecordingAborted({@required this.error});
+  ChatComposerRecordingFailed({@required this.error});
+}
+
+class ChatComposerReplayStopped extends ChatComposerState {}
+
+class ChatComposerReplayTimeUpdated extends ChatComposerState {
+  final List<double> dbPeakList;
+  final int replayTime;
+
+  ChatComposerReplayTimeUpdated({@required this.dbPeakList, @required this.replayTime});
 }
 
 class ChatComposerRecordingImageOrVideoStopped extends ChatComposerState {

--- a/lib/src/chat/chat_composer_mixin.dart
+++ b/lib/src/chat/chat_composer_mixin.dart
@@ -42,6 +42,7 @@
 
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:ox_coi/src/adaptiveWidgets/adaptive_icon.dart';
 import 'package:ox_coi/src/adaptiveWidgets/adaptive_icon_button.dart';
@@ -172,6 +173,7 @@ mixin ChatComposer {
     @required Function onAudioPlayingStopped,
     @required Function onRecordVideoPressed,
     @required Function onCaptureImagePressed,
+    @required Function onMicTapDown,
     @required BuildContext context,
     @required String text,
     @required bool isLocked,
@@ -237,6 +239,7 @@ mixin ChatComposer {
       widgets.add(GestureDetector(
         onLongPressStart: onRecordAudioPressed,
         onLongPressEnd: onRecordAudioStoppedLongPress,
+        onTapDown: onMicTapDown,
         child: Container(
           decoration: BoxDecoration(
             color: isLocked || isStopped || type == ComposerModeType.compose

--- a/lib/src/chat/chat_composer_mixin.dart
+++ b/lib/src/chat/chat_composer_mixin.dart
@@ -52,6 +52,7 @@ import 'package:ox_coi/src/ui/color.dart';
 import 'package:ox_coi/src/ui/custom_theme.dart';
 import 'package:ox_coi/src/ui/dimensions.dart';
 import 'package:ox_coi/src/utils/keyMapping.dart';
+import 'package:ox_coi/src/widgets/audio_visualizer.dart';
 
 enum ComposerModeType {
   compose,
@@ -89,7 +90,7 @@ mixin ChatComposer {
         icon = AdaptiveSuperellipseIcon(
           icon: IconSource.delete,
           color: CustomTheme.of(context).onSurface.withOpacity(barely),
-          iconColor: CustomTheme.of(context).accent,
+          iconColor: CustomTheme.of(context).error,
         );
         onPressed = onAudioRecordingAbort;
         break;
@@ -105,8 +106,29 @@ mixin ChatComposer {
       @required ComposerModeType type,
       @required TextEditingController textController,
       @required Function onTextChanged,
-      @required String text}) {
-    return Flexible(child: ComposerModeType.isVoiceRecording == type ? getText(text) : getInputTextField(textController, onTextChanged, context));
+      @required bool isStopped,
+      @required bool isPlaying,
+      int replayTime = 0,
+      List<double> dbPeakList}) {
+    Widget child;
+    if (ComposerModeType.isVoiceRecording == type) {
+      if (!isPlaying && !isStopped) {
+        child = LayoutBuilder(builder: (context, constraints) {
+          return VoicePainter(
+            dbPeakList: dbPeakList,
+            color: CustomTheme.of(context).onSurface,
+            withChild: true,
+            width: constraints.maxWidth,
+          );
+        });
+      } else {
+        child = AudioPlayback(dbPeakList: dbPeakList, replayTime: replayTime);
+      }
+    } else {
+      child = getInputTextField(textController, onTextChanged, context);
+    }
+
+    return Flexible(child: child);
   }
 
   Widget getInputTextField(TextEditingController textController, Function onTextChanged, BuildContext context) {
@@ -135,69 +157,173 @@ mixin ChatComposer {
 
   Widget getText(String text) {
     return Container(
-      child: Text(text),
-      width: double.infinity,
+      child: Text(text ?? ""),
     );
   }
 
-  List<Widget> buildRightComposerPart(
-      {@required ComposerModeType type,
-      @required Function onSendText,
-      @required Function onRecordAudioPressed,
-      @required Function onRecordVideoPressed,
-      @required Function onCaptureImagePressed,
-      @required BuildContext context}) {
+  List<Widget> buildRightComposerPart({
+    @required ComposerModeType type,
+    @required Function onSendText,
+    @required Function onRecordAudioPressed,
+    @required Function onRecordAudioStopped,
+    @required Function onRecordAudioStoppedLongPress,
+    @required Function onRecordAudioLocked,
+    @required Function onAudioPlaying,
+    @required Function onAudioPlayingStopped,
+    @required Function onRecordVideoPressed,
+    @required Function onCaptureImagePressed,
+    @required BuildContext context,
+    @required String text,
+    @required bool isLocked,
+    @required bool isStopped,
+    @required bool isPlaying,
+  }) {
     List<Widget> widgets = List();
-    switch (type) {
-      case ComposerModeType.compose:
-        widgets.add(AdaptiveIconButton(
-          icon: AdaptiveSuperellipseIcon(
-            icon: IconSource.mic,
-            color: CustomTheme.of(context).onSurface.withOpacity(barely),
-            iconColor: CustomTheme.of(context).accent,
+    if (type != ComposerModeType.isComposing) {
+      widgets.add(Visibility(
+        visible: type == ComposerModeType.compose,
+        child: Row(
+          children: <Widget>[
+            AdaptiveIconButton(
+              icon: AdaptiveSuperellipseIcon(
+                icon: IconSource.camera,
+                color: CustomTheme.of(context).onSurface.withOpacity(barely),
+                iconColor: CustomTheme.of(context).accent,
+              ),
+              onPressed: onCaptureImagePressed,
+            ),
+            AdaptiveIconButton(
+              icon: AdaptiveSuperellipseIcon(
+                icon: IconSource.videocam,
+                color: CustomTheme.of(context).onSurface.withOpacity(barely),
+                iconColor: CustomTheme.of(context).accent,
+              ),
+              onPressed: onRecordVideoPressed,
+            )
+          ],
+        ),
+      ));
+      widgets.add(Visibility(
+        visible: type != ComposerModeType.compose,
+        child: SizedBox(
+          width: 70.0,
+          child: Row(
+            children: <Widget>[
+              Visibility(
+                visible: !isStopped,
+                child: Padding(
+                  padding: const EdgeInsets.only(left: 4.0),
+                  child: Icon(
+                    Icons.fiber_manual_record,
+                    size: 12,
+                    color: Colors.red,
+                  ),
+                ),
+              ),
+              Visibility(
+                visible: isStopped,
+                child: Padding(
+                  padding: const EdgeInsets.only(left: 18.0),
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.only(left: 8.0, right: 4.0),
+                child: getText(text),
+              )
+            ],
           ),
-          onPressed: onRecordAudioPressed,
-          key: Key(KeyChatComposerMixinOnRecordAudioPressedIcon),
-        ));
-        widgets.add(AdaptiveIconButton(
-          icon: AdaptiveSuperellipseIcon(
-            icon: IconSource.camera,
-            color: CustomTheme.of(context).onSurface.withOpacity(barely),
-            iconColor: CustomTheme.of(context).accent,
+        ),
+      ));
+      widgets.add(GestureDetector(
+        onLongPressStart: onRecordAudioPressed,
+        onLongPressEnd: onRecordAudioStoppedLongPress,
+        child: Container(
+          decoration: BoxDecoration(
+            color: isLocked || isStopped || type == ComposerModeType.compose
+                ? Colors.transparent
+                : CustomTheme.of(context).onSurface.withOpacity(barely),
+            borderRadius: BorderRadius.all(Radius.circular(30.0)),
           ),
-          onPressed: onCaptureImagePressed,
-        ));
-        widgets.add(AdaptiveIconButton(
-          icon: AdaptiveSuperellipseIcon(
-            icon: IconSource.videocam,
-            color: CustomTheme.of(context).onSurface.withOpacity(barely),
-            iconColor: CustomTheme.of(context).accent,
+          child: Row(
+            children: <Widget>[
+              Visibility(
+                visible: type == ComposerModeType.isVoiceRecording && !isStopped,
+                child: AdaptiveIconButton(
+                  icon: AdaptiveSuperellipseIcon(
+                    icon: isLocked ? IconSource.lock : IconSource.openLock,
+                    color: Colors.transparent,
+                    iconColor: CustomTheme.of(context).accent,
+                    iconSize: 16.0,
+                  ),
+                  onPressed: onRecordAudioLocked,
+                ),
+              ),
+              Visibility(
+                visible: type == ComposerModeType.compose,
+                child: AdaptiveIconButton(
+                  icon: AdaptiveSuperellipseIcon(
+                    icon: IconSource.mic,
+                    color: CustomTheme.of(context).onSurface.withOpacity(barely),
+                    iconColor: CustomTheme.of(context).accent,
+                  ),
+                ),
+              ),
+              Visibility(
+                visible: type == ComposerModeType.isVoiceRecording && !isStopped,
+                child: AdaptiveIconButton(
+                  icon: AdaptiveSuperellipseIcon(
+                    icon: IconSource.stopPlay,
+                    color: CustomTheme.of(context).accent,
+                    iconColor: CustomTheme.of(context).white,
+                  ),
+                  onPressed: onRecordAudioStopped,
+                ),
+              ),
+              Visibility(
+                visible: type == ComposerModeType.isVoiceRecording && isStopped,
+                child: Container(
+                    padding: EdgeInsets.only(left: 50.0),
+                    child: Row(
+                      children: <Widget>[
+                        Visibility(
+                          visible: !isPlaying,
+                          child: AdaptiveIconButton(
+                            icon: AdaptiveSuperellipseIcon(
+                              icon: IconSource.play,
+                              color: CustomTheme.of(context).accent,
+                              iconColor: CustomTheme.of(context).white,
+                            ),
+                            onPressed: onAudioPlaying,
+                          ),
+                        ),
+                        Visibility(
+                          visible: isPlaying,
+                          child: AdaptiveIconButton(
+                            icon: AdaptiveSuperellipseIcon(
+                              icon: IconSource.stopPlay,
+                              color: CustomTheme.of(context).accent,
+                              iconColor: CustomTheme.of(context).white,
+                            ),
+                            onPressed: onAudioPlayingStopped,
+                          ),
+                        )
+                      ],
+                    )),
+              )
+            ],
           ),
-          onPressed: onRecordVideoPressed,
-        ));
-        break;
-      case ComposerModeType.isComposing:
-        widgets.add(AdaptiveIconButton(
-          icon: AdaptiveSuperellipseIcon(
-            icon: IconSource.send,
-            color: CustomTheme.of(context).onSurface.withOpacity(barely),
-            iconColor: CustomTheme.of(context).accent,
-          ),
-          onPressed: onSendText,
-          key: Key(KeyChatComposerMixinOnSendTextIcon),
-        ));
-        break;
-      case ComposerModeType.isVoiceRecording:
-        widgets.add(AdaptiveIconButton(
-          icon: AdaptiveSuperellipseIcon(
-            icon: IconSource.send,
-            color: CustomTheme.of(context).onSurface.withOpacity(barely),
-            iconColor: CustomTheme.of(context).accent,
-          ),
-          onPressed: onRecordAudioPressed,
-          key: Key(KeyChatComposerMixinOnRecordAudioSendIcon),
-        ));
-        break;
+        ),
+      ));
+    } else {
+      widgets.add(AdaptiveIconButton(
+        icon: AdaptiveSuperellipseIcon(
+          icon: IconSource.send,
+          color: CustomTheme.of(context).accent,
+          iconColor: CustomTheme.of(context).white,
+        ),
+        onPressed: onSendText,
+        key: Key(KeyChatComposerMixinOnSendTextIcon),
+      ));
     }
     return widgets;
   }

--- a/lib/src/chatlist/chat_list.dart
+++ b/lib/src/chatlist/chat_list.dart
@@ -248,10 +248,10 @@ class _ChatListState extends State<ChatList> {
             findChildIndexCallback: (Key key) {
               final ValueKey valueKey = key;
               var id = extractId(valueKey);
-              if(state.chatListItemWrapper.ids.contains(id)) {
+              if (state.chatListItemWrapper.ids.contains(id)) {
                 var indexOf = state.chatListItemWrapper.ids.indexOf(id);
                 return indexOf;
-              }else{
+              } else {
                 return null;
               }
             }));

--- a/lib/src/ui/dimensions.dart
+++ b/lib/src/ui/dimensions.dart
@@ -204,3 +204,6 @@ const errorBannerPositionLeft = 0.0;
 const errorBannerPositionRight = 0.0;
 const errorBannerPositionTop = 24.0;
 const errorBannerElevation = 4.0;
+
+//Voice Recording
+const audioPlaybackTopPadding = 30.0;

--- a/lib/src/ui/dimensions.dart
+++ b/lib/src/ui/dimensions.dart
@@ -92,6 +92,8 @@ const iconDismissiblePadding = 20.0;
 const composerHorizontalPadding = 8.0;
 const composerTextFieldPadding = 8.0;
 const composeTextBorderRadius = 24.0;
+const composerMessagePadding = 56.0;
+const messageListPadding = 8.0;
 
 // Chat profile
 const chatProfileDividerPadding = 8.0;

--- a/lib/src/utils/date.dart
+++ b/lib/src/utils/date.dart
@@ -48,7 +48,7 @@ const formatterDateAndTime = [dd, '.', mm, '.', yyyy, ' - ', HH, ':', nn];
 const formatterTime = [HH, ':', nn];
 const formatterDate = [dd, '.', mm];
 const formatterDateLong = [dd, '. ', MM];
-const formatterTimer = [nn, ':', ss, ':', SSS];
+const formatterTimer = [nn, ':', ss,];
 const formatterVideoTime = [n, ':', ss];
 const formatterDateTimeFile = [yy, '-', mm, '-', dd, '_', HH, '-', nn, '-', ss];
 

--- a/lib/src/utils/vibration.dart
+++ b/lib/src/utils/vibration.dart
@@ -1,0 +1,45 @@
+/*
+ * OPEN-XCHANGE legal information
+ *
+ * All intellectual property rights in the Software are protected by
+ * international copyright laws.
+ *
+ *
+ * In some countries OX, OX Open-Xchange and open xchange
+ * as well as the corresponding Logos OX Open-Xchange and OX are registered
+ * trademarks of the OX Software GmbH group of companies.
+ * The use of the Logos is not covered by the Mozilla Public License 2.0 (MPL 2.0).
+ * Instead, you are allowed to use these Logos according to the terms and
+ * conditions of the Creative Commons License, Version 2.5, Attribution,
+ * Non-commercial, ShareAlike, and the interpretation of the term
+ * Non-commercial applicable to the aforementioned license is published
+ * on the web site https://www.open-xchange.com/terms-and-conditions/.
+ *
+ * Please make sure that third-party modules and libraries are used
+ * according to their respective licenses.
+ *
+ * Any modifications to this package must retain all copyright notices
+ * of the original copyright holder(s) for the original code used.
+ *
+ * After any such modifications, the original and derivative code shall remain
+ * under the copyright of the copyright holder(s) and/or original author(s) as stated here:
+ * https://www.open-xchange.com/legal/. The contributing author shall be
+ * given Attribution for the derivative code and a license granting use.
+ *
+ * Copyright (C) 2016-2020 OX Software GmbH
+ * Mail: info@open-xchange.com
+ *
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public License 2.0
+ * for more details.
+ */
+
+import 'package:vibrate/vibrate.dart';
+
+vibrateMedium ()=> Vibrate.feedback(FeedbackType.medium);

--- a/lib/src/widgets/audio_visualizer.dart
+++ b/lib/src/widgets/audio_visualizer.dart
@@ -1,0 +1,191 @@
+/*
+ * OPEN-XCHANGE legal information
+ *
+ * All intellectual property rights in the Software are protected by
+ * international copyright laws.
+ *
+ *
+ * In some countries OX, OX Open-Xchange and open xchange
+ * as well as the corresponding Logos OX Open-Xchange and OX are registered
+ * trademarks of the OX Software GmbH group of companies.
+ * The use of the Logos is not covered by the Mozilla Public License 2.0 (MPL 2.0).
+ * Instead, you are allowed to use these Logos according to the terms and
+ * conditions of the Creative Commons License, Version 2.5, Attribution,
+ * Non-commercial, ShareAlike, and the interpretation of the term
+ * Non-commercial applicable to the aforementioned license is published
+ * on the web site https://www.open-xchange.com/terms-and-conditions/.
+ *
+ * Please make sure that third-party modules and libraries are used
+ * according to their respective licenses.
+ *
+ * Any modifications to this package must retain all copyright notices
+ * of the original copyright holder(s) for the original code used.
+ *
+ * After any such modifications, the original and derivative code shall remain
+ * under the copyright of the copyright holder(s) and/or original author(s) as stated here:
+ * https://www.open-xchange.com/legal/. The contributing author shall be
+ * given Attribution for the derivative code and a license granting use.
+ *
+ * Copyright (C) 2016-2020 OX Software GmbH
+ * Mail: info@open-xchange.com
+ *
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public License 2.0
+ * for more details.
+ */
+
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:ox_coi/src/chat/chat_composer_bloc.dart';
+import 'package:ox_coi/src/chat/chat_composer_event_state.dart';
+import 'package:ox_coi/src/ui/custom_theme.dart';
+import 'package:ox_coi/src/widgets/custom_painters.dart';
+
+class AudioPlayback extends StatefulWidget {
+  final List<double> dbPeakList;
+  final int replayTime;
+
+  AudioPlayback({@required this.dbPeakList, @required this.replayTime});
+
+  @override
+  _AudioPlaybackState createState() => _AudioPlaybackState();
+}
+
+class _AudioPlaybackState extends State<AudioPlayback> {
+  int _dragUpdateValue = 0;
+  var _replayFactor = 1.0;
+  var _replayTime;
+  var _peakListLength;
+
+  @override
+  void initState() {
+    super.initState();
+    _replayFactor = 1.0;
+    _replayTime = 0;
+    _dragUpdateValue = 0;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        var changeableList = List<double>();
+
+        changeableList.addAll(widget.dbPeakList);
+        _peakListLength = changeableList.length;
+
+        var spaceNeeded = (_peakListLength * 3);
+        if (spaceNeeded > constraints.maxWidth) {
+          var start = ((_peakListLength - (((_peakListLength - constraints.maxWidth)).round())) / 3).round();
+          changeableList.removeRange(start, widget.dbPeakList.length);
+          _replayFactor = (widget.dbPeakList.length / changeableList.length);
+        }
+
+        _replayTime = (widget.replayTime / _replayFactor).round();
+        if (_replayTime > changeableList.length) {
+          _replayTime--;
+        }
+
+        return Container(
+          padding: const EdgeInsets.only(top: 30.0),
+          child: GestureDetector(
+            onHorizontalDragUpdate: _onHorizontalDragUpdate,
+            onHorizontalDragEnd: _onHorizontalDragEnd,
+            onTapUp: _onTapUp,
+            behavior: HitTestBehavior.opaque,
+            child: Stack(
+              children: <Widget>[
+                VoicePainter(
+                  dbPeakList: changeableList,
+                  color: CustomTheme.of(context).onSurface,
+                  withChild: true,
+                  width: constraints.maxWidth,
+                ),
+                VoicePainter(
+                  dbPeakList: changeableList.getRange(0, _replayTime).toList(),
+                  color: CustomTheme.of(context).accent,
+                  withChild: false,
+                  width: constraints.maxWidth,
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  void _onHorizontalDragUpdate(DragUpdateDetails details) {
+    _dragUpdateValue = (details.localPosition.dx / 2).round();
+    final listLength = widget.dbPeakList.length;
+
+    if (_dragUpdateValue >= 0 && _dragUpdateValue <= listLength) {
+      BlocProvider.of<ChatComposerBloc>(context)?.add(UpdateReplayTime(replayTime: _dragUpdateValue));
+    } else if (_dragUpdateValue > listLength) {
+      BlocProvider.of<ChatComposerBloc>(context)?.add(UpdateReplayTime(replayTime: listLength));
+    } else if (_dragUpdateValue <= 0) {
+      BlocProvider.of<ChatComposerBloc>(context)?.add(UpdateReplayTime(replayTime: 0));
+    }
+  }
+
+  void _onHorizontalDragEnd(DragEndDetails details) {
+    _seekToPosition(_dragUpdateValue);
+  }
+
+  void _onTapUp(TapUpDetails details) {
+    final x = (details.localPosition.dx / 2).round();
+
+    _seekToPosition(x);
+  }
+
+  _seekToPosition(int position) {
+    final listLength = widget.dbPeakList.length;
+    if (position >= 0 && position <= listLength) {
+      BlocProvider.of<ChatComposerBloc>(context)?.add(ReplayAudioSeek(seekValue: position));
+    } else if (position > listLength) {
+      BlocProvider.of<ChatComposerBloc>(context)?.add(ReplayAudioSeek(seekValue: listLength));
+    } else if (position <= 0) {
+      BlocProvider.of<ChatComposerBloc>(context)?.add(ReplayAudioSeek(seekValue: 0));
+    }
+  }
+}
+
+class VoicePainter extends StatefulWidget {
+  final List<double> dbPeakList;
+  final Color color;
+  final bool withChild;
+  final double width;
+
+  VoicePainter({@required this.dbPeakList, @required this.color, @required this.withChild, @required this.width});
+
+  @override
+  _VoicePainterState createState() => _VoicePainterState();
+}
+
+class _VoicePainterState extends State<VoicePainter> {
+  @override
+  Widget build(BuildContext context) {
+    return CustomPaint(
+      child: widget.withChild
+          ? Container(
+              width: widget.width,
+              child: CustomPaint(
+                painter: HorizontalLinePainter(color: widget.color),
+              ),
+            )
+          : Container(),
+      size: Size(widget.width, 0.0),
+      painter: BarPainter(peakLevel: widget.dbPeakList, callback: callback, color: widget.color),
+    );
+  }
+
+  callback(bool removeFirstEntry, int cutoffValue) {
+    BlocProvider.of<ChatComposerBloc>(context)?.add(RemoveFirstAudioDBPeak(removeFirstEntry: removeFirstEntry, cutoffValue: cutoffValue));
+  }
+}

--- a/lib/src/widgets/custom_painters.dart
+++ b/lib/src/widgets/custom_painters.dart
@@ -40,6 +40,7 @@
  * for more details.
  */
 
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 
@@ -60,6 +61,91 @@ class CurvePainter extends CustomPainter {
     path.close();
 
     canvas.drawPath(path, paint);
+  }
+
+  @override
+  bool shouldRepaint(CustomPainter oldDelegate) {
+    return true;
+  }
+}
+
+class BarPainter extends CustomPainter {
+  final List<double> peakLevel;
+  final Function callback;
+  final Color color;
+  double barWidth;
+  double spaceWidth = 1.0;
+
+  BarPainter({@required this.peakLevel, @required this.callback, @required this.color, this.barWidth = 2.0});
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    var paint = Paint()
+      ..color = color
+      ..style = PaintingStyle.fill
+      ..strokeWidth = barWidth;
+
+    var x = 0.0;
+    var y = 0.0;
+    var height = 30.0;
+
+    peakLevel?.forEach((peak) {
+      y = peak > height ? y : peak;
+      canvas.drawLine(Offset(x, y), Offset(x, -y), paint);
+      x = (x + barWidth + spaceWidth);
+    });
+
+    if (x >= size.width) {
+      var cutoff = x - size.width;
+
+      int cutoffIndex = (cutoff / (barWidth + spaceWidth)).round();
+
+      callback(true, cutoffIndex);
+    } else {
+      callback(false, 1);
+    }
+  }
+
+  @override
+  bool shouldRepaint(BarPainter oldDelegate) {
+    return true;
+  }
+}
+
+class HorizontalLinePainter extends CustomPainter {
+  Paint _paint;
+
+  HorizontalLinePainter({@required color}) {
+    _paint = Paint()
+      ..color = color
+      ..strokeWidth = 1
+      ..strokeCap = StrokeCap.round;
+  }
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    canvas.drawLine(Offset(0.0, 0.0), Offset(size.width, 0.0), _paint);
+  }
+
+  @override
+  bool shouldRepaint(CustomPainter oldDelegate) {
+    return true;
+  }
+}
+
+class VerticalLinePainter extends CustomPainter {
+  Paint _paint;
+
+  VerticalLinePainter({@required color}) {
+    _paint = Paint()
+      ..color = color
+      ..strokeWidth = 1
+      ..strokeCap = StrokeCap.round;
+  }
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    canvas.drawLine(Offset(0.0, 10.0), Offset(0.0, -10.0), _paint);
   }
 
   @override

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -910,6 +910,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.8"
+  vibrate:
+    dependency: "direct main"
+    description:
+      name: vibrate
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.0.4"
   video_player:
     dependency: "direct main"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -186,7 +186,7 @@ packages:
   delta_chat_core:
     dependency: "direct main"
     description:
-      path: "../flutter-deltachat-core"
+      path: "..\\flutter-deltachat-core"
       relative: true
     source: path
     version: "0.0.1"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -55,6 +55,7 @@ dependencies:
   superellipse_shape: ^0.1.5
   transparent_image: ^1.0.0
   url_launcher: ^5.4.1
+  vibrate: ^0.0.4
   video_player: ^0.10.5+2
   qr_flutter: ^3.2.0
   qr_mobile_vision:


### PR DESCRIPTION
**Link to the given issue**
https://github.com/open-xchange/ox-coi/issues/257

**Describe what the problem was / what the new feature is**
The user can stop the recording by releasing the button. With a swipe to the left he can lock the recording, which means that the user don't need to hold the screen any more to record. The user can swipe up or press the send button to send the audio. After stopping the recording the user can replay the audio file, seek to a position and delete the file. The audio peaks are visualized with different bars.

**Describe your solution**
- Added two new icons for stop and locking.
- The chat_composer_bloc.dart has a _cutoffValue which is used to get a cutted dbPeakList to animate the overflow while recording when there is not enough space.
- The audio_visualizer.dart contains the new Widgets to visualize the audio peaks and handle gestures while the replay.
- The AudioPlayback Widget is used to handle the complete replay of the audio file (calculation and gestures) and the VoicePainter Widget is used to paint the peaks.

**Additional context**
- Clean up in the chat_list.dart
- The last message in a chat has now always a bottom padding of 56.0 when the list is scrolled to the top.