### PR TITLE
Clarify wording after key export #408

### DIFF
--- a/lib/src/l10n/l.dart
+++ b/lib/src/l10n/l.dart
@@ -309,9 +309,11 @@ class L {
   static final settingBase = _translationKey("Base Settings");
   static final settingConfigurationChangeFailed = _translationKey("Configuration change aborted");
   // Do you want to import your keys from folder X (e.g. Do you want to import your keys from "/home/alice/keys"?)
-  static final settingSecurityImportKeysTextX = _translationKey("Do you want to import your keys from \"%s\"? If no keys are in that folder, the operation will fail.");
+  static final settingSecurityImportKeysAndroidText = _translationKey("Do you want to import your keys from your application folder? \n\nIf no keys are in that folder, the operation will fail.");
+  static final settingSecurityImportKeysIOSText = _translationKey("Do you want to import your keys from your app documents folder? \n\nIf no keys are in that folder, the operation will fail.");
   // Do you want to export your keys to folder X (e.g. "Do you want to save your keys in "/home/alice/keys"?")
-  static final settingSecurityExportKeysTextX = _translationKey("Do you want to save your keys in \"%s\"?");
+  static final settingSecurityExportKeysAndroidTextX = _translationKey("Do you want to save your keys in the application folder? \n\nThe path is:\n\"%s\"");
+  static final settingSecurityExportKeysIOSText = _translationKey("Do you want to save your keys in your devices documents folder? \n\nYou can access it via the \"Files App\".");
   static final settingCopyCode = _translationKey("Copy code");
   static final settingExportKeys = _translationKey("Expert: Export keys");
   static final settingImportKeys = _translationKey("Expert: Import keys");

--- a/lib/src/settings/settings_security.dart
+++ b/lib/src/settings/settings_security.dart
@@ -40,6 +40,8 @@
  * for more details.
  */
 
+import 'dart:io';
+
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:ox_coi/src/adaptiveWidgets/adaptive_app_bar.dart';
@@ -199,14 +201,17 @@ class _SettingsSecurityState extends State<SettingsSecurity> {
     String title;
     String text;
     String path = await getExportImportPath();
+    if(Platform.isAndroid){
+      path = path.substring(path.getIndexAfterLastOf('0'));
+    }
     Type navigationType;
     if (type == SettingsSecurityType.exportKeys) {
       title = L10n.get(L.settingExportKeys);
-      text = L10n.getFormatted(L.settingSecurityExportKeysTextX, [path]);
+      text = Platform.isAndroid ? L10n.getFormatted(L.settingSecurityExportKeysAndroidTextX, [path]) : L10n.get(L.settingSecurityExportKeysIOSText);
       navigationType = Type.settingsExportKeysDialog;
     } else if (type == SettingsSecurityType.importKeys) {
       title = L10n.get(L.settingImportKeys);
-      text = L10n.getFormatted(L.settingSecurityImportKeysTextX, [path]);
+      text = Platform.isAndroid ? L10n.get(L.settingSecurityImportKeysAndroidText) : L10n.get(L.settingSecurityImportKeysIOSText);
       navigationType = Type.settingsImportKeysDialog;
     }
     showConfirmationDialog(


### PR DESCRIPTION
**Link to the given issue**
https://github.com/open-xchange/ox-coi/issues/408

**Describe what the problem was / what the new feature is**
The wording for import/export was not really understandable for the user.

**Describe your solution**
- New and different Strings for both platforms
- On Android we show a user readable path for export