### PR TITLE
OT-725 When sending pictures I sometimes succeed in sending empty messages

### DIFF
--- a/lib/src/chat/chat.dart
+++ b/lib/src/chat/chat.dart
@@ -666,7 +666,9 @@ class _ChatState extends State<Chat> with ChatComposer, ChatCreateMixin, InviteM
     final String text = _textController.text;
     _textController.clear();
     if (_filePath.isEmpty) {
-      _messageListBloc.add(SendMessage(text: text));
+      if (text.isNotEmpty) {
+        _messageListBloc.add(SendMessage(text: text));
+      }
     } else {
       int type = getType();
       if (type == ChatMsg.typeVoice) _onAudioRecordingAbort();


### PR DESCRIPTION
**Link to the given issue**
https://jira.open-xchange.com/browse/OT-725

**Describe what the problem was / what the new feature is**
If the app needs a moment to load a huge image / attachment, it is possible to send empty message if the user is fast.

**Describe your solution**
Only allowing non-empty text messages.
