### PR TITLE
Add test for flagged messages per chat #439

### DIFF
--- a/lib/src/chat/chat.dart
+++ b/lib/src/chat/chat.dart
@@ -327,6 +327,7 @@ class _ChatState extends State<Chat> with ChatComposer, ChatCreateMixin, InviteM
                   : GestureDetector(
                       behavior: HitTestBehavior.opaque,
                       onTap: () => _chatTitleTapped(),
+                      key: Key(keyChatIconTitleText),
                       child: buildRow(imagePath, name, subTitle, color, context, isVerified),
                     ),
               leading: AppBarBackButton(context: context),

--- a/lib/src/chat/chat_profile.dart
+++ b/lib/src/chat/chat_profile.dart
@@ -58,6 +58,7 @@ import 'package:ox_coi/src/navigation/navigation.dart';
 import 'package:ox_coi/src/utils/key_generator.dart';
 import 'package:ox_coi/src/widgets/dynamic_appbar.dart';
 
+
 class ChatProfile extends StatefulWidget {
   final int chatId;
   final int messageId;

--- a/lib/src/chat/chat_profile_single.dart
+++ b/lib/src/chat/chat_profile_single.dart
@@ -62,6 +62,8 @@ import 'package:ox_coi/src/widgets/list_group_header.dart';
 import 'package:ox_coi/src/widgets/profile_body.dart';
 import 'package:ox_coi/src/widgets/profile_header.dart';
 import 'package:ox_coi/src/widgets/settings_item.dart';
+import 'package:ox_coi/src/utils/keyMapping.dart';
+
 
 class ChatProfileOneToOne extends StatefulWidget {
   final int chatId;
@@ -134,6 +136,7 @@ class _ChatProfileOneToOneState extends State<ChatProfileOneToOne> {
           SettingsItem(
             icon: IconSource.flag,
             text: L10n.get(L.settingItemFlaggedTitle),
+            key: Key(keyChatProfileSingleIconSourceFlaggedTitle),
             iconBackground: CustomTheme.of(context).flagIcon,
             onTap: () => _settingsItemTapped(context, SettingsItemName.flagged),
           ),

--- a/lib/src/utils/keyMapping.dart
+++ b/lib/src/utils/keyMapping.dart
@@ -95,6 +95,7 @@ const keyChatListCreateChatButton = "keyChatListChatFloatingActionButton";
 
 const keyChatCreatePersonAddIcon = "keyChatCreatePersonAddIcon";
 const keyChatCreateGroupAddIcon = "keyChatcreateGroupAddIcon";
+const keyChatIconTitleText="keyChatIconTitleText";
 
 const keyChatCreateGroupParticipantsSummitIconButton = "keyChatCreateGroupParticipantsSummitIconButton";
 
@@ -103,6 +104,7 @@ const keyChatCreateGroupSettingsGroupNameField = "keyChatCreateGroupSettingsGrou
 
 const keyChatProfileGroupEditIcon = "ChatProfileGroupEditIcon";
 const keyChatProfileGroupAddParticipant = "keyChatProfileGroupAddParticipant";
+const keyChatProfileSingleIconSourceFlaggedTitle= "keyChatProfileIconSourceFlaggedTitle";
 
 const keyEditNameCheckIcon = "keyEditNameICheckIcon";
 const keyEditNameEditableProfileHeader = "keyEditNameValidatableTextFormField";

--- a/test_driver/flagged_test.dart
+++ b/test_driver/flagged_test.dart
@@ -39,7 +39,7 @@
  *  * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
  *  * or FITNESS FOR A PARTICULAR PURPOSE. See the Mozilla Public License 2.0
  *  * for more details.
- *  
+ *
  *
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
@@ -55,12 +55,11 @@
 import 'package:flutter_driver/flutter_driver.dart';
 import 'package:ox_coi/src/l10n/l.dart';
 import 'package:test/test.dart';
+import 'package:ox_coi/src/utils/keyMapping.dart';
 
 import 'setup/helper_methods.dart';
 import 'setup/main_test_setup.dart';
 import 'setup/test_constants.dart';
-import 'package:ox_coi/src/utils/keyMapping.dart';
-
 
 void main() {
   FlutterDriver driver;
@@ -72,60 +71,50 @@ void main() {
     await teardownDriver(driver);
   });
 
-  group('Test messages fonctionslity', () {
+  group('Test flagged messages per chat', () {
     final flagUnFlag = L.getKey(L.messageActionFlagUnflag);
-    final forward = L.getKey(L.messageActionForward);
-    final textToDelete = 'Text to delete';
-    final copy = 'Copy';
+    final name2ContactFinder = find.text(name2);
+    final name3ContactFinder = find.text(name3);
 
-    final meContactFinder = find.text(nameMe);
-    final textToDeleteFinder = find.byValueKey(messageIdFour);
-
-    test(': Get contacts and add new contacts.', () async {
-      await driver.tap(contactsFinder);
-      await driver.tap(cancelFinder);
-      var actualMeContact = await driver.getText(meContactFinder);
-      expect(actualMeContact, nameMe);
-      await addNewContact(driver, name3, email3);
+    test(': Add two chats.', () async {
+      await createNewChat(driver, email2, name2);
+      await createNewChat(driver, email3, name3);
     });
 
-    test(': Create chat and write something.', () async {
-      await driver.tap(meContactFinder);
-      await driver.tap(find.text(L.getKey(L.chatOpen)));
-      await writeChatFromChat(driver, messageIdOne);
-    });
-
-    test(': Flagged messages from  meChat.', () async {
+    test(': Edit two messages in chat name2 and flags both. ', () async {
+      await driver.tap(name2ContactFinder);
+      await writeTextInChat(driver, messageIdOne);
+      await writeTextInChat(driver, messageIdTwo,inputTestMessage);
       await flaggedMessage(driver, flagUnFlag, finderMessageOne);
+      await flaggedMessage(driver, flagUnFlag, finderMessageTwo);
       await driver.tap(pageBackFinder);
-      await navigateTo(driver, L.getKey(L.profile));
+    });
+
+    test(': Edit one messages in chat name3 ', () async {
+      await driver.tap(name3ContactFinder);
+      await writeTextInChat(driver, messageIdThree);
+      await flaggedMessage(driver, flagUnFlag, finderMessageThree);
+    });
+
+    test(': Check flagged messages. ', () async {
+      await driver.tap(find.byValueKey(keyChatIconTitleText));
+      await driver.tap(find.byValueKey(keyChatProfileSingleIconSourceFlaggedTitle));
+      await driver.waitFor(finderMessageOne);
+      await driver.waitFor(finderMessageTwo);
+      await driver.waitFor(finderMessageThree);
+      await driver.tap(pageBackFinder);
     });
 
     test(': UnFlagged messages.', () async {
-      await driver.tap(find.byValueKey(keyUserProfileFlagIconSource));
+      await driver.tap(name3ContactFinder);
+      await driver.tap(find.byValueKey(keyChatProfileSingleIconSourceFlaggedTitle));
       await unFlaggedMessage(driver, flagUnFlag, messageIdOne);
-      await driver.waitForAbsent(find.byValueKey(inputHelloWorld));
+      await unFlaggedMessage(driver, flagUnFlag, messageIdTwo);
+      await unFlaggedMessage(driver, flagUnFlag, messageIdThree);
+      await driver.waitForAbsent(finderMessageOne);
+      await driver.waitForAbsent(finderMessageTwo);
+      await driver.waitForAbsent(finderMessageThree);
       await driver.tap(pageBackFinder);
-      await navigateTo(driver, L.getPluralKey(L.chatP));
-      await driver.tap(chatSavedMessagesFinder);
-    });
-
-    test(': Forward message.', () async {
-      await forwardMessageTo(driver, name3, forward);
-      await driver.waitFor(finderMessageThree);
-      await driver.tap(pageBackFinder);
-      await driver.tap(chatSavedMessagesFinder);
-    });
-
-    test(': Copy message from meContact and it paste in meContact.', () async {
-      final paste = isAndroid() ? 'PASTE' : 'Paste';
-      await copyAndPasteMessage(driver, copy, paste);
-    });
-
-    test(': Delete message.', () async {
-      await writeTextInChat(driver, messageIdFour, textToDelete);
-      await deleteMessage(textToDeleteFinder, driver);
-      await driver.waitForAbsent(textToDeleteFinder);
     });
   });
 }

--- a/test_driver/flagged_test.dart
+++ b/test_driver/flagged_test.dart
@@ -54,8 +54,8 @@
 
 import 'package:flutter_driver/flutter_driver.dart';
 import 'package:ox_coi/src/l10n/l.dart';
-import 'package:test/test.dart';
 import 'package:ox_coi/src/utils/keyMapping.dart';
+import 'package:test/test.dart';
 
 import 'setup/helper_methods.dart';
 import 'setup/main_test_setup.dart';
@@ -65,55 +65,69 @@ void main() {
   FlutterDriver driver;
   setUpAll(() async {
     driver = await setupAndGetDriver();
+    await createNewChat(driver, email2, name2);
+    await createNewChat(driver, email3, name3);
   });
 
   tearDownAll(() async {
     await teardownDriver(driver);
   });
 
-  group('Test flagged messages per chat', () {
+  group('Flagged messages per chat', () {
     final flagUnFlag = L.getKey(L.messageActionFlagUnflag);
     final name2ContactFinder = find.text(name2);
     final name3ContactFinder = find.text(name3);
 
-    test(': Add two chats.', () async {
-      await createNewChat(driver, email2, name2);
-      await createNewChat(driver, email3, name3);
-    });
-
-    test(': Edit two messages in chat name2 and flags both. ', () async {
+    test(': Add messages in chat "name2" and flag those.', () async {
       await driver.tap(name2ContactFinder);
       await writeTextInChat(driver, messageIdOne);
-      await writeTextInChat(driver, messageIdTwo,inputTestMessage);
+      await writeTextInChat(driver, messageIdTwo, inputTestMessage);
       await flaggedMessage(driver, flagUnFlag, finderMessageOne);
       await flaggedMessage(driver, flagUnFlag, finderMessageTwo);
-      await driver.tap(pageBackFinder);
-    });
-
-    test(': Edit one messages in chat name3 ', () async {
-      await driver.tap(name3ContactFinder);
-      await writeTextInChat(driver, messageIdThree);
-      await flaggedMessage(driver, flagUnFlag, finderMessageThree);
-    });
-
-    test(': Check flagged messages. ', () async {
       await driver.tap(find.byValueKey(keyChatIconTitleText));
       await driver.tap(find.byValueKey(keyChatProfileSingleIconSourceFlaggedTitle));
       await driver.waitFor(finderMessageOne);
       await driver.waitFor(finderMessageTwo);
-      await driver.waitFor(finderMessageThree);
+      await driver.waitForAbsent(finderMessageThree);
+      await driver.tap(pageBackFinder);
+      await driver.tap(pageBackFinder);
       await driver.tap(pageBackFinder);
     });
 
-    test(': UnFlagged messages.', () async {
+    test(': Add message in chat "name3" and flag it', () async {
       await driver.tap(name3ContactFinder);
+      await writeTextInChat(driver, messageIdThree);
+      await flaggedMessage(driver, flagUnFlag, finderMessageThree);
+      await driver.tap(find.byValueKey(keyChatIconTitleText));
       await driver.tap(find.byValueKey(keyChatProfileSingleIconSourceFlaggedTitle));
-      await unFlaggedMessage(driver, flagUnFlag, messageIdOne);
-      await unFlaggedMessage(driver, flagUnFlag, messageIdTwo);
-      await unFlaggedMessage(driver, flagUnFlag, messageIdThree);
       await driver.waitForAbsent(finderMessageOne);
       await driver.waitForAbsent(finderMessageTwo);
+      await driver.waitFor(finderMessageThree);
+      await driver.tap(pageBackFinder);
+      await driver.tap(pageBackFinder);
+      await driver.tap(pageBackFinder);
+    });
+
+    test(': Unflag message in chat "name2".', () async {
+      await driver.tap(name2ContactFinder);
+      await driver.tap(find.byValueKey(keyChatIconTitleText));
+      await driver.tap(find.byValueKey(keyChatProfileSingleIconSourceFlaggedTitle));
+      await unflagMessage(driver, flagUnFlag, messageIdTwo);
+      await driver.waitFor(finderMessageOne);
+      await driver.waitForAbsent(finderMessageTwo);
       await driver.waitForAbsent(finderMessageThree);
+      await driver.tap(pageBackFinder);
+      await driver.tap(pageBackFinder);
+      await driver.tap(pageBackFinder);
+    });
+  });
+
+  group("All flagged messages", () {
+    test(': Check all flagged messages', () async {
+      await driver.tap(profileFinder);
+      await driver.tap(flaggedMessagesFinder);
+      await driver.waitFor(finderMessageOne);
+      await driver.waitFor(finderMessageThree);
       await driver.tap(pageBackFinder);
     });
   });

--- a/test_driver/messages_actions_test.dart
+++ b/test_driver/messages_actions_test.dart
@@ -103,7 +103,7 @@ void main() {
 
     test(': UnFlagged messages.', () async {
       await driver.tap(find.byValueKey(keyUserProfileFlagIconSource));
-      await unFlaggedMessage(driver, flagUnFlag, messageIdOne);
+      await unflagMessage(driver, flagUnFlag, messageIdOne);
       await driver.waitForAbsent(find.byValueKey(inputHelloWorld));
       await driver.tap(pageBackFinder);
       await navigateTo(driver, L.getPluralKey(L.chatP));

--- a/test_driver/setup/helper_methods.dart
+++ b/test_driver/setup/helper_methods.dart
@@ -150,7 +150,7 @@ Future blockOneContactFromContacts(FlutterDriver driver, String contactNameToBlo
   await driver.tap(find.text(blockContact));
 }
 
-Future unFlaggedMessage(FlutterDriver driver,String flagUnFlag, int messageIdToUnFlagged) async {
+Future unflagMessage(FlutterDriver driver,String flagUnFlag, int messageIdToUnFlagged) async {
   SerializableFinder messageToUnFlaggedFinder = find.byValueKey(messageIdToUnFlagged);
   await driver.waitFor(messageToUnFlaggedFinder);
   await performLongPress(driver, messageToUnFlaggedFinder);

--- a/test_driver/setup/helper_methods.dart
+++ b/test_driver/setup/helper_methods.dart
@@ -150,9 +150,8 @@ Future blockOneContactFromContacts(FlutterDriver driver, String contactNameToBlo
   await driver.tap(find.text(blockContact));
 }
 
-Future unFlaggedMessage(FlutterDriver driver, String flagUnFlag, String messageToUnFlagged) async {
-  SerializableFinder messageToUnFlaggedFinder = find.byValueKey(messageIdOne);
-  await driver.tap(find.byValueKey(keyUserProfileFlagIconSource));
+Future unFlaggedMessage(FlutterDriver driver,String flagUnFlag, int messageIdToUnFlagged) async {
+  SerializableFinder messageToUnFlaggedFinder = find.byValueKey(messageIdToUnFlagged);
   await driver.waitFor(messageToUnFlaggedFinder);
   await performLongPress(driver, messageToUnFlaggedFinder);
   await driver.tap(find.text(flagUnFlag));
@@ -170,7 +169,7 @@ Future deleteMessage(SerializableFinder textToDeleteFinder, FlutterDriver driver
 }
 
 Future copyAndPasteMessage(FlutterDriver driver, String copy, String paste) async {
-  await performLongPress(driver, find.byValueKey(messageIdOne));
+  await performLongPress(driver, finderMessageOne);
   await driver.tap(find.text(copy));
   await performLongPress(driver, composeInputFinder);
   await driver.tap(find.text(paste));
@@ -178,7 +177,7 @@ Future copyAndPasteMessage(FlutterDriver driver, String copy, String paste) asyn
 }
 
 Future forwardMessageTo(FlutterDriver driver, String contactToForward, String forward) async {
-  await performLongPress(driver, find.byValueKey(messageIdOne));
+  await performLongPress(driver, finderMessageOne);
   await driver.tap(find.text(forward));
   await driver.tap(find.text(contactToForward));
 }

--- a/test_driver/setup/test_constants.dart
+++ b/test_driver/setup/test_constants.dart
@@ -81,6 +81,7 @@ const messageIdFour = 13;
 // Finders
 final pageBackFinder = find.byValueKey(keyBackOrCloseButton);
 final profileFinder = find.text(L.getKey(L.profile));
+final flaggedMessagesFinder = find.text(L.getKey(L.settingItemFlaggedTitle));
 final contactsFinder = find.text(L.getPluralKey(L.contactP));
 final chatsFinder = find.text(L.getPluralKey(L.chatP));
 final signInFinder = find.text(L.getKey(L.loginSignIn));

--- a/test_driver/setup/test_constants.dart
+++ b/test_driver/setup/test_constants.dart
@@ -68,13 +68,15 @@ const textName = 'Name';
 const textSavedMessages = 'Saved messages';
 
 // Input
-const inputHelloWorld = 'Hello world, hello really. Hi at world. Helllllloooo Woooooooorrrrllllldddddddd. Helllllloooo Woooooooorrrrllllldddddddd. Helllllloooo Woooooooorrrrllllldddddddd.';
+const inputHelloWorld = 'Hello world, hello really. Hi at world. Helllllloooo Woooooooorrrrllllldddddddd. Helllllloooo Woooooooorrrrllllldddddddd. Helllllloooo Woooooooorrrrllllldddddddd. ';
+const inputTestMessage = 'Test message, hello really. Hi at world. Helllllloooo Woooooooorrrrllllldddddddd. Helllllloooo Woooooooorrrrllllldddddddd. Tessssss Messageeeee Twoooooooooooooo. ';
 
 // Message Ids
 const messageIdOne = 10;
 const messageIdTwo = 11;
 const messageIdThree = 12;
 const messageIdFour = 13;
+
 
 // Finders
 final pageBackFinder = find.byValueKey(keyBackOrCloseButton);
@@ -90,3 +92,6 @@ final userSettingsSubmitFinder = find.byValueKey(keyUserSettingsCheckIconButton)
 final contactChangeNameInputFinder = find.byValueKey(keyContactChangeNameValidatableTextFormField);
 final contactChangeSubmitFinder = find.byValueKey(keyContactChangeCheckIconButton);
 final chatSavedMessagesFinder = find.text(textSavedMessages);
+final finderMessageOne = find.byValueKey(messageIdOne);
+final finderMessageTwo = find.byValueKey(messageIdTwo);
+final finderMessageThree = find.byValueKey(messageIdThree);

--- a/tools/test.runIntegrationTests.sh
+++ b/tools/test.runIntegrationTests.sh
@@ -103,17 +103,16 @@ do
     if [[ -f "$test" ]]; then
         echo "### Running test: $test"
 
-         if [[ ${target} = ${TARGET_ANDROID} ]]; then
-            flutter drive -d ${deviceId} --target=test_driver/setup/app.dart --driver=${test} --flavor development >> ${LOG_FILE} 2>&1
-            testResult=$?
+        if [[ ${target} = ${TARGET_ANDROID} ]]; then
+            adb uninstall ${appId} >> ${LOG_FILE} 2>&1
 
         elif [[ ${target} = ${TARGET_IOS} ]]; then
             xcrun simctl uninstall ${deviceId} ${appId} >> ${LOG_FILE} 2>&1
             sleep 5
             setupIos
+        fi
             flutter drive -d ${deviceId} --no-build --target=test_driver/setup/app.dart --driver=${test} --flavor development >> ${LOG_FILE} 2>&1
             testResult=$?
-         fi
 
         if [[ ${testResult} -eq 0 ]]; then
             echo "  [OK] $test"


### PR DESCRIPTION
**Link to the given issue**
#439 

**Describe what the problem was / what the new feature is**
Add test for flagged messages per chat

**Describe your solution**
 **Workflow:**
1. Login
2. Add two chats
3. Edit two messages in the first chat, flags both and return to the chat view.
4. Edit one message in the second chat, flags that one, and navigate to the flagged view to check if all flagged messages are available, and back to the chat view.
5. Navigate to flag view though one chat, unflag all messages and back to the chat view.

