### PR TITLE
OT-757: Regression: Flagged Messages not filtered per Chat

### DIFF
--- a/lib/src/chat/chat_profile_group.dart
+++ b/lib/src/chat/chat_profile_group.dart
@@ -171,7 +171,7 @@ class _ChatProfileGroupState extends State<ChatProfileGroup> {
       case SettingsItemName.flagged:
         _navigation.push(
           context,
-          MaterialPageRoute(builder: (context) => Flagged()),
+          MaterialPageRoute(builder: (context) => Flagged(chatId: widget.chatId)),
         );
         break;
       case SettingsItemName.notification:

--- a/lib/src/chat/chat_profile_single.dart
+++ b/lib/src/chat/chat_profile_single.dart
@@ -185,7 +185,7 @@ class _ChatProfileOneToOneState extends State<ChatProfileOneToOne> {
       case SettingsItemName.flagged:
         _navigation.push(
           context,
-          MaterialPageRoute(builder: (context) => Flagged()),
+          MaterialPageRoute(builder: (context) => Flagged(chatId: widget.chatId)),
         );
         break;
       case SettingsItemName.notification:

--- a/lib/src/contact/contact_details.dart
+++ b/lib/src/contact/contact_details.dart
@@ -142,12 +142,13 @@ class _ContactDetailsState extends State<ContactDetails> with ChatCreateMixin {
                     iconBackground: CustomTheme.of(context).chatIcon,
                     onTap: () => createChatFromContact(context, widget.contactId),
                   ),
-                  SettingsItem(
-                    icon: IconSource.flag,
-                    text: L10n.get(L.settingItemFlaggedTitle),
-                    iconBackground: CustomTheme.of(context).flagIcon,
-                    onTap: () => _settingsItemTapped(context, SettingsItemName.flagged),
-                  ),
+//TODO: This should be discussed (Flagged messages per user)!
+//                  SettingsItem(
+//                    icon: IconSource.flag,
+//                    text: L10n.get(L.settingItemFlaggedTitle),
+//                    iconBackground: CustomTheme.of(context).flagIcon,
+//                    onTap: () => _settingsItemTapped(context, SettingsItemName.flagged),
+//                  ),
                   SettingsItem(
                     key: Key(keyUserProfileBlockIconSource),
                     icon: IconSource.block,


### PR DESCRIPTION
**Link to the given issue**
Fixes #483, Closes #483 

### Fixes
* adds missing `chatId` parameter when calling `Flagged` widget
* comments some code out (needs to be discussed) for flagged messages per contact