### PR TITLE
Forward state for messages #337

### DIFF
--- a/lib/src/l10n/l.dart
+++ b/lib/src/l10n/l.dart
@@ -78,6 +78,7 @@ class L {
   static final file = _translationKey("File");
   static final error = _translationKey("Error");
   static final forward = _translationKey("Forward");
+  static final forwarded = _translationKey("Forwarded");
   static final gallery = _translationKey("Gallery");
   static final image = _translationKey("Image");
   static final import = _translationKey("Import");

--- a/lib/src/message/message_builder.dart
+++ b/lib/src/message/message_builder.dart
@@ -53,6 +53,8 @@ import 'package:ox_coi/src/brandable/custom_theme.dart';
 import 'package:ox_coi/src/extensions/color_apis.dart';
 import 'package:ox_coi/src/extensions/numbers_apis.dart';
 import 'package:ox_coi/src/extensions/string_markdown.dart';
+import 'package:ox_coi/src/l10n/l.dart';
+import 'package:ox_coi/src/l10n/l10n.dart';
 import 'package:ox_coi/src/message/message_attachment_bloc.dart';
 import 'package:ox_coi/src/message/message_attachment_event_state.dart';
 import 'package:ox_coi/src/message/message_item_bloc.dart';
@@ -130,6 +132,33 @@ Future<void> _launch({@required String url}) async {
     await launch(url);
   }
 }
+
+class MessagePartForwarded extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    var messageStateData = _getMessageStateData(context);
+    Color color = messageStateData.isOutgoing ? CustomTheme.of(context).onSecondary.half() : CustomTheme.of(context).onSurface.half();
+    double topPadding = messageStateData.isGroup && !messageStateData.isOutgoing ? dimension2dp : dimension8dp;
+    return Padding(
+      padding: EdgeInsets.only(top: topPadding, left: messagesHorizontalInnerPadding, right: messagesHorizontalInnerPadding,),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: <Widget>[
+          AdaptiveIcon(
+            icon: IconSource.forward,
+            color: color,
+            size: dimension16dp,
+          ),
+          Text(
+            L10n.get(L.forwarded),
+            style: Theme.of(context).textTheme.caption.apply(color: color),
+          )
+        ],
+      ),
+    );
+  }
+}
+
 
 String _getText(BuildContext context) {
   return MessageData.of(context).useInformationText ? _getMessageStateData(context).informationText : _getMessageStateData(context).text;
@@ -519,7 +548,7 @@ class MessagePartFlag extends StatelessWidget {
 
 EdgeInsetsGeometry getNamePaddingForGroups(BuildContext context) {
   var messageStateData = _getMessageStateData(context);
-  if (messageStateData.isGroup && !messageStateData.isOutgoing) {
+  if (messageStateData.isGroup && !messageStateData.isOutgoing || messageStateData.isForwarded) {
     return EdgeInsets.only(
       top: dimension2dp,
       bottom: messagesVerticalInnerPadding,

--- a/lib/src/message/message_item_bloc.dart
+++ b/lib/src/message/message_item_bloc.dart
@@ -113,7 +113,7 @@ class MessageItemBloc extends Bloc<MessageItemEvent, MessageItemState> {
       bool hasFile = await message.hasFile();
       bool isSetupMessage = await message.isSetupMessage();
       String text = await message.getText();
-
+      bool isForwarded = await message.isForwarded();
       String informationText;
       if (isSetupMessage) {
         informationText = L10n.get(L.autocryptChatMessagePlaceholder);
@@ -177,6 +177,7 @@ class MessageItemBloc extends Bloc<MessageItemEvent, MessageItemState> {
         showTime: showTime,
         encryptionStatusChanged: encryptionStatusChanged,
         isGroup: isGroup,
+        isForwarded: isForwarded,
         messageInfo: messageInfo,
       );
       yield MessageItemStateSuccess(messageStateData: messageStateData);
@@ -276,6 +277,7 @@ class MessageItemBloc extends Bloc<MessageItemEvent, MessageItemState> {
       ChatMsg.methodMessageGetFilename,
       ChatMsg.methodMessageGetState,
       ChatMsg.methodMessageShowPadlock,
+      ChatMsg.methodMessageIsForwarded,
     ]);
   }
 

--- a/lib/src/message/message_item_event_state.dart
+++ b/lib/src/message/message_item_event_state.dart
@@ -133,6 +133,7 @@ class MessageStateData extends Equatable {
   final bool showTime;
   final bool encryptionStatusChanged;
   final bool isGroup;
+  final bool isForwarded;
   final String messageInfo;
 
   MessageStateData({
@@ -152,6 +153,7 @@ class MessageStateData extends Equatable {
     @required this.showTime,
     @required this.encryptionStatusChanged,
     @required this.isGroup,
+    @required this.isForwarded,
     @required this.messageInfo,
   });
 
@@ -172,6 +174,7 @@ class MessageStateData extends Equatable {
       showTime,
       encryptionStatusChanged,
       isGroup,
+      isForwarded,
       messageInfo}) {
     return MessageStateData(
       text: text ?? this.text,
@@ -190,6 +193,7 @@ class MessageStateData extends Equatable {
       showTime: showTime ?? this.showTime,
       encryptionStatusChanged: encryptionStatusChanged ?? this.encryptionStatusChanged,
       isGroup: isGroup ?? this.isGroup,
+      isForwarded: isForwarded ?? this.isForwarded,
       messageInfo: messageInfo ?? this.messageInfo,
     );
   }
@@ -212,6 +216,7 @@ class MessageStateData extends Equatable {
         showTime,
         encryptionStatusChanged,
         isGroup,
+        isForwarded,
       ];
 }
 

--- a/lib/src/message/message_received.dart
+++ b/lib/src/message/message_received.dart
@@ -59,6 +59,7 @@ class MessageReceived extends StatelessWidget {
   Widget build(BuildContext context) {
     var contactStateData = messageStateData.contactStateData;
     var isGroup = messageStateData.isGroup;
+    var isForwarded = messageStateData.isForwarded;
     return FractionallySizedBox(
       alignment: Alignment.topLeft,
       widthFactor: messagesWidthFactor,
@@ -102,6 +103,10 @@ class MessageReceived extends StatelessWidget {
                             ),
                           )
                         : Container(constraints: BoxConstraints(maxWidth: zero)),
+                    Visibility(
+                      visible: isForwarded,
+                      child: MessagePartForwarded(),
+                    ),
                     messageStateData.hasFile ? MessageAttachment() : MessageText(),
                   ],
                 ),

--- a/lib/src/message/message_sent.dart
+++ b/lib/src/message/message_sent.dart
@@ -55,6 +55,7 @@ class MessageSent extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    var isForwarded = messageStateData.isForwarded;
     return FractionallySizedBox(
       alignment: Alignment.topRight,
       widthFactor: 0.8,
@@ -72,7 +73,17 @@ class MessageSent extends StatelessWidget {
             MessagePartFlag(),
             Flexible(
               child: MessageMaterial(
-                child: messageStateData.hasFile ? MessageAttachment() : MessageText(),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: <Widget>[
+                    Visibility(
+                      visible: isForwarded,
+                      child: MessagePartForwarded(),
+                    ),
+                    messageStateData.hasFile ? MessageAttachment() : MessageText(),
+                  ],
+                ),
               ),
             ),
             MessagePartState(),


### PR DESCRIPTION
**Link to the given issue**
https://github.com/open-xchange/ox-coi/issues/337

**Describe what the problem was / what the new feature is**
It was not possible to see which messages where forwarded.

**Describe your solution**
- Added the StatelessWidget MessagePartForwarded to the MessageBuilder
- Added translation key "Forwarded"
- Added the forwarded widget where needed

**Additional context**
- This needs to be merged first https://github.com/open-xchange/flutter-deltachat-core/pull/77
- And the plugin iOS part needs to be implemented
