### PR TITLE
OT-761 App was black after unlocking device

### DIFF
--- a/lib/src/chat/chat_bloc.dart
+++ b/lib/src/chat/chat_bloc.dart
@@ -198,7 +198,7 @@ class ChatBloc extends Bloc<ChatEvent, ChatState> {
         subTitle = L10n.get(L.chatMessagesSelf);
       } else {
         Contact contact = _contactRepository.get(chatContactId);
-        subTitle = await contact.getAddress();
+        subTitle = await contact?.getAddress() ?? "";
       }
     }
     add(


### PR DESCRIPTION
**Link to the given issue**
https://jira.open-xchange.com/browse/OT-761

**Describe what the problem was / what the new feature is**
The stacktrace said `The method 'getAddress' was called on null`. The black screen problem was not reproducable for me.

**Describe your solution**
Added a null check and return an empty String in a null case.