### PR TITLE
Empty user in group profile after deletion #491

### DIFF
--- a/lib/src/l10n/l.dart
+++ b/lib/src/l10n/l.dart
@@ -190,7 +190,7 @@ class L {
   static final contactEditedSuccess = _translationKey("Contact successfully edited");
   static final contactVerifiedSuccess = _translationKey("Contact verified");
   static final contactAddFailedAlreadyExists = _translationKey("Could not add contact. Email address already in use.");
-  static final contactDeleteFailed = _translationKey("Could not delete contact.");
+  static final contactDeleteFailed = _translationKey("Could not delete contact. You may have a group conversation with this contact.");
   static final contactDeleteWithActiveChatFailed =
       _translationKey("Could not delete contact. Active chats with contact found, please remove those chats first.");
   static final contactDelete = _translationKey("Delete contact");


### PR DESCRIPTION
**Link to the given issue**
https://github.com/open-xchange/ox-coi/issues/491

**Describe your solution**
Modified error string for the case that a contact is in a group and can't be deleted.