### PR TITLE
Ot 758 update secondary and accent color for dark mode

### DIFF
--- a/lib/src/brandable/custom_theme.dart
+++ b/lib/src/brandable/custom_theme.dart
@@ -72,7 +72,7 @@ class CustomerThemes {
   );
 
   static final BrandedTheme darkTheme = BrandedTheme(
-    accent: const Color(0xFF0076FF),
+    accent: const Color(0xFF00A0FF),
     onAccent: const Color(0xFFF3F3F3),
     info: const Color(0xFF4E4E4E),
     onInfo: Colors.white,
@@ -83,7 +83,7 @@ class CustomerThemes {
     onBackground: const Color(0xFFF3F3F3),
     surface: const Color(0xFF1F1F1F),
     onSurface: const Color(0xFFF3F3F3),
-    secondary: const Color(0xFF0D47A1),
+    secondary: const Color(0xFF052D4B),
     onSecondary: const Color(0xFFF3F3F3),
     error: const Color(0xFFE53935),
     onError: Colors.white,


### PR DESCRIPTION
**Link to the given issue**
https://jira.open-xchange.com/browse/OT-758
https://github.com/open-xchange/ox-coi/issues/486

**Describe what the problem was / what the new feature is**
The current contrast between Secondary and Accent color is too low

**Describe your solution**
Changed colors for Secondary and Accent in dark mode

