### PR TITLE
Adding a new contact with empty fields lets slip the email icon #531

### DIFF
--- a/lib/src/contact/contact_change.dart
+++ b/lib/src/contact/contact_change.dart
@@ -94,6 +94,7 @@ class _ContactChangeState extends State<ContactChange> {
     (context) => L10n.get(L.name),
     key: Key(keyContactChangeNameValidatableTextFormField),
     hintText: (context) => L10n.get(L.contactName),
+    icon: AdaptiveIcon(icon: IconSource.person),
   );
   ValidatableTextFormField _emailField;
 
@@ -112,8 +113,9 @@ class _ContactChangeState extends State<ContactChange> {
       _emailField = ValidatableTextFormField(
         (context) => L10n.get(L.emailAddress),
         key: Key(keyContactChangeEmailValidatableTextFormField),
-        textFormType: TextFormType.email,
+        textType: TextType.email,
         inputType: TextInputType.emailAddress,
+        icon: AdaptiveIcon(icon: IconSource.mail),
         needValidation: true,
         validationHint: (context) => L10n.get(L.loginCheckMail),
       );
@@ -237,15 +239,7 @@ class _ContactChangeState extends State<ContactChange> {
                 color: CustomTheme.of(context).surface,
                 child: Padding(
                   padding: const EdgeInsets.symmetric(horizontal: formHorizontalPadding),
-                  child: Row(
-                    children: <Widget>[
-                      AdaptiveIcon(icon: IconSource.person),
-                      Padding(
-                        padding: EdgeInsets.only(right: iconFormPadding),
-                      ),
-                      Expanded(child: _nameField),
-                    ],
-                  ),
+                  child: _nameField,
                 ),
               ),
             ),
@@ -255,15 +249,7 @@ class _ContactChangeState extends State<ContactChange> {
                 color: CustomTheme.of(context).surface,
                 child: Padding(
                   padding: const EdgeInsets.symmetric(horizontal: formHorizontalPadding),
-                  child: Row(
-                    children: <Widget>[
-                      AdaptiveIcon(icon: IconSource.mail),
-                      Padding(
-                        padding: const EdgeInsets.only(right: iconFormPadding),
-                      ),
-                      Expanded(child: _emailField),
-                    ],
-                  ),
+                  child: _emailField,
                 ),
               ),
             ),

--- a/lib/src/login/login_provider_signin.dart
+++ b/lib/src/login/login_provider_signin.dart
@@ -42,6 +42,7 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:ox_coi/src/brandable/brandable_icon.dart';
 import 'package:ox_coi/src/error/error_bloc.dart';
 import 'package:ox_coi/src/l10n/l.dart';
 import 'package:ox_coi/src/l10n/l10n.dart';
@@ -85,20 +86,20 @@ class _ProviderSignInState extends State<ProviderSignIn> {
   ValidatableTextFormField emailField = ValidatableTextFormField(
     (context) => L10n.get(L.emailAddress),
     hintText: (context) => L10n.get(L.emailAddress),
-    textFormType: TextFormType.email,
+    textType: TextType.email,
     inputType: TextInputType.emailAddress,
     needValidation: true,
     validationHint: (context) => L10n.get(L.loginCheckMail),
-    showIcon: true,
+    icon: AdaptiveIcon(icon: IconSource.person),
     key: Key(keyProviderSignInEmailTextField),
   );
   ValidatableTextFormField passwordField = ValidatableTextFormField(
     (context) => L10n.get(L.password),
     hintText: (context) => L10n.get(L.password),
-    textFormType: TextFormType.password,
+    textType: TextType.password,
     needValidation: true,
     validationHint: (context) => L10n.get(L.loginCheckPassword),
-    showIcon: true,
+    icon: AdaptiveIcon(icon: IconSource.lock),
     key: Key(keyProviderSignInPasswordTextField),
   );
 

--- a/lib/src/login/password_changed.dart
+++ b/lib/src/login/password_changed.dart
@@ -85,9 +85,10 @@ class _PasswordChangedState extends State<PasswordChanged> {
   ValidatableTextFormField passwordField = ValidatableTextFormField(
     (context) => L10n.get(L.password),
     key: Key(keySettingsManuelFormValidatableTextFormFieldPasswordField),
-    textFormType: TextFormType.password,
+    textType: TextType.password,
     needValidation: true,
     validationHint: (context) => L10n.get(L.loginCheckPassword),
+    icon: AdaptiveIcon(icon: IconSource.lock),
   );
 
   @override
@@ -97,11 +98,12 @@ class _PasswordChangedState extends State<PasswordChanged> {
     _loginBloc = LoginBloc(BlocProvider.of<ErrorBloc>(context));
     emailField = ValidatableTextFormField(
       (context) => L10n.get(L.emailAddress),
-      textFormType: TextFormType.email,
+      textType: TextType.email,
       inputType: TextInputType.emailAddress,
       needValidation: true,
       enabled: false,
       validationHint: (context) => L10n.get(L.loginCheckMail),
+      icon: AdaptiveIcon(icon: IconSource.person),
     );
     _passwordChangedBloc.add(LoadData());
   }

--- a/lib/src/settings/settings_manual_form.dart
+++ b/lib/src/settings/settings_manual_form.dart
@@ -65,7 +65,7 @@ class _SettingsManualFormState extends State<SettingsManualForm> {
   ValidatableTextFormField emailField;
   ValidatableTextFormField passwordField = ValidatableTextFormField(
     (context) => L10n.get(L.password),
-    textFormType: TextFormType.password,
+    textType: TextType.password,
     needValidation: true,
     validationHint: (context) => L10n.get(L.loginCheckPassword),
     key: Key(keySettingsManuelFormValidatableTextFormFieldPasswordField),
@@ -80,7 +80,7 @@ class _SettingsManualFormState extends State<SettingsManualForm> {
   );
   ValidatableTextFormField imapPortField = ValidatableTextFormField(
     (context) => L10n.get(L.settingIMAPPort),
-    textFormType: TextFormType.port,
+    textType: TextType.port,
     inputType: TextInputType.number,
     needValidation: true,
     validationHint: (context) => L10n.get(L.loginCheckPort),
@@ -90,7 +90,7 @@ class _SettingsManualFormState extends State<SettingsManualForm> {
   );
   ValidatableTextFormField smtpPasswordField = ValidatableTextFormField(
     (context) => L10n.get(L.settingSMTPPassword),
-    textFormType: TextFormType.password,
+    textType: TextType.password,
     needValidation: false,
     validationHint: (context) => L10n.get(L.loginCheckPassword),
   );
@@ -101,7 +101,7 @@ class _SettingsManualFormState extends State<SettingsManualForm> {
   );
   ValidatableTextFormField smtpPortField = ValidatableTextFormField(
     (context) => L10n.get(L.settingSMTPPort),
-    textFormType: TextFormType.port,
+    textType: TextType.port,
     inputType: TextInputType.number,
     needValidation: true,
     validationHint: (context) => L10n.get(L.loginCheckPort),
@@ -112,7 +112,7 @@ class _SettingsManualFormState extends State<SettingsManualForm> {
     super.initState();
     emailField = ValidatableTextFormField(
       (context) => L10n.get(L.emailAddress),
-      textFormType: TextFormType.email,
+      textType: TextType.email,
       inputType: TextInputType.emailAddress,
       needValidation: true,
       enabled: widget.isLogin,

--- a/lib/src/widgets/validatable_text_form_field.dart
+++ b/lib/src/widgets/validatable_text_form_field.dart
@@ -44,7 +44,7 @@ import 'package:flutter/material.dart';
 import 'package:ox_coi/src/brandable/brandable_icon.dart';
 import 'package:ox_coi/src/extensions/string_apis.dart';
 
-enum TextFormType {
+enum TextType {
   normal,
   email,
   password,
@@ -52,7 +52,7 @@ enum TextFormType {
 }
 
 class ValidatableTextFormField extends StatefulWidget {
-  final TextFormType textFormType;
+  final TextType textType;
   final Function labelText;
   final Function hintText;
   final TextInputType inputType;
@@ -60,19 +60,19 @@ class ValidatableTextFormField extends StatefulWidget {
   final Function validationHint;
   final bool enabled;
   final int maxLines;
-  final bool showIcon;
+  final AdaptiveIcon icon;
   final TextEditingController controller = TextEditingController();
 
   ValidatableTextFormField(this.labelText,
       {this.hintText,
       Key key,
-      this.textFormType = TextFormType.normal,
+      this.textType = TextType.normal,
       this.inputType = TextInputType.text,
       this.needValidation = false,
       this.validationHint,
       this.enabled = true,
       this.maxLines = 1,
-      this.showIcon = false})
+      this.icon})
       : super(key: key);
 
   @override
@@ -85,7 +85,7 @@ class _ValidatableTextFormFieldState extends State<ValidatableTextFormField> {
   @override
   Widget build(BuildContext context) {
     return TextFormField(
-        obscureText: widget.textFormType == TextFormType.password && !_showReadablePassword,
+        obscureText: widget.textType == TextType.password && !_showReadablePassword,
         maxLines: widget.maxLines,
         controller: widget.controller,
         keyboardType: widget.inputType,
@@ -96,18 +96,21 @@ class _ValidatableTextFormFieldState extends State<ValidatableTextFormField> {
   }
 
   InputDecoration _getInputDecoration() {
-    if (widget.textFormType == TextFormType.password) {
+    if (widget.textType == TextType.password) {
       return InputDecoration(
         labelText: widget.labelText(context),
         hintText: widget.hintText != null ? widget.hintText(context) : "",
-        prefixIcon: widget.showIcon ? AdaptiveIcon(icon: IconSource.lock) : null,
-        suffixIcon: IconButton(icon: AdaptiveIcon(icon: _showReadablePassword ?  IconSource.visibility : IconSource.visibilityOff), onPressed: _togglePasswordVisibility),
+        icon: widget.icon,
+        suffixIcon: IconButton(
+          icon: AdaptiveIcon(icon: _showReadablePassword ? IconSource.visibility : IconSource.visibilityOff),
+          onPressed: _togglePasswordVisibility,
+        ),
       );
     } else {
       return InputDecoration(
         labelText: widget.labelText(context),
         hintText: widget.hintText != null ? widget.hintText(context) : "",
-        prefixIcon: widget.textFormType == TextFormType.email && widget.showIcon ? AdaptiveIcon(icon: IconSource.person) : null,
+        icon: widget.icon,
       );
     }
   }
@@ -115,13 +118,13 @@ class _ValidatableTextFormFieldState extends State<ValidatableTextFormField> {
   String _validate(String value) {
     var valid = true;
     if (widget.needValidation) {
-      if (widget.textFormType == TextFormType.normal || widget.textFormType == TextFormType.password) {
+      if (widget.textType == TextType.normal || widget.textType == TextType.password) {
         valid = value.isNotEmpty;
-      } else if (widget.textFormType == TextFormType.email) {
+      } else if (widget.textType == TextType.email) {
         var trimmedEmail = value.trim();
         valid = trimmedEmail.isEmail;
         widget.controller.text = trimmedEmail;
-      } else if (widget.textFormType == TextFormType.port) {
+      } else if (widget.textType == TextType.port) {
         valid = value.isPort;
       }
     }


### PR DESCRIPTION
**Link to the given issue**
Fixes #531 

**Describe what the problem was / what the new feature is**

We manually added the icons to the UI, but our text fields should and could supply those.

**Describe your solution**

- Let the text fields handle prefix and suffix icon
- Use the `icon` and the `suffixIcon` properties (icon shows the icon on the left in front of the actual field and not inside and that's what we want)
- I replaced our "specific icon on / off" logic with a more dynamic approach. We can now just set any icon we want, if one is required or just omit it

**Additional context**

- Renamed TextFormType to TextType as it's shorter and clearer
- Added the person and lock icon on the password change screen (to match the normal login) 
- lib/src/settings/settings_manual_form.dart only contains renamings
