### PR TITLE
UI optimizations #534

### DIFF
--- a/lib/src/chat/chat.dart
+++ b/lib/src/chat/chat.dart
@@ -881,7 +881,7 @@ class _ChatState extends State<Chat> with ChatComposer, ChatCreateMixin, InviteM
       showInformationDialog(
         context: context,
         title: L10n.get(L.contactNoPhoneNumber),
-        content: L10n.get(L.contactNoPhoneNumberText),
+        contentText: L10n.get(L.contactNoPhoneNumberText),
         navigatable: Navigatable(Type.contactNoNumberDialog),
       );
     } else {

--- a/lib/src/chat/chat_profile_group.dart
+++ b/lib/src/chat/chat_profile_group.dart
@@ -116,19 +116,21 @@ class _ChatProfileGroupState extends State<ChatProfileGroup> {
                     children: <Widget>[
                       buildProfileImageAndTitle(chatState),
                       SettingsItem(
+                        pushesNewScreen: true,
                         icon: IconSource.flag,
                         text: L10n.get(L.settingItemFlaggedTitle),
                         iconBackground: CustomTheme.of(context).flagIcon,
-                        onTap: () => _settingsItemTapped(context, SettingsItemName.flagged),
+                        onTap: () => _navigation.push(context, MaterialPageRoute(builder: (context) => Flagged(chatId: widget.chatId))),
                       ),
                       ListGroupHeader(
                         text: L10n.get(L.settingP),
                       ),
                       SettingsItem(
+                        pushesNewScreen: true,
                         icon: IconSource.notifications,
                         text: L10n.get(L.settingItemNotificationsTitle),
                         iconBackground: CustomTheme.of(context).notificationIcon,
-                        onTap: () => _settingsItemTapped(context, SettingsItemName.notification),
+                        onTap: () => _navigation.pushNamed(context, Navigation.settingsNotifications),
                       ),
                       ListGroupHeader(
                         text: L10n.getFormatted(L.participantXP, [state.contactIds.length], count: state.contactIds.length),
@@ -136,6 +138,7 @@ class _ChatProfileGroupState extends State<ChatProfileGroup> {
                       Visibility(
                         visible: !chatState.isRemoved,
                         child: SettingsItem(
+                          pushesNewScreen: true,
                           icon: IconSource.groupAdd,
                           text: L10n.get(L.participantAdd),
                           key: Key(keyChatProfileGroupAddParticipant),
@@ -146,6 +149,7 @@ class _ChatProfileGroupState extends State<ChatProfileGroup> {
                       ),
                       _buildGroupMemberList(state, chatState.isRemoved),
                       SettingsItem(
+                        pushesNewScreen: false,
                         icon: IconSource.delete,
                         text: chatState.isRemoved ? L10n.get(L.groupDelete) : L10n.get(L.groupLeave),
                         iconBackground: CustomTheme.of(context).error,
@@ -166,22 +170,6 @@ class _ChatProfileGroupState extends State<ChatProfileGroup> {
         }
       },
     );
-  }
-
-  _settingsItemTapped(BuildContext context, SettingsItemName settingsItemName) {
-    switch (settingsItemName) {
-      case SettingsItemName.flagged:
-        _navigation.push(
-          context,
-          MaterialPageRoute(builder: (context) => Flagged(chatId: widget.chatId)),
-        );
-        break;
-      case SettingsItemName.notification:
-        _navigation.pushNamed(context, Navigation.settingsNotifications);
-        break;
-      default:
-        break;
-    }
   }
 
   ProfileData buildProfileImageAndTitle(ChatStateSuccess state) {

--- a/lib/src/chat/chat_profile_single.dart
+++ b/lib/src/chat/chat_profile_single.dart
@@ -58,12 +58,11 @@ import 'package:ox_coi/src/flagged/flagged.dart';
 import 'package:ox_coi/src/l10n/l.dart';
 import 'package:ox_coi/src/l10n/l10n.dart';
 import 'package:ox_coi/src/navigation/navigation.dart';
+import 'package:ox_coi/src/utils/keyMapping.dart';
 import 'package:ox_coi/src/widgets/list_group_header.dart';
 import 'package:ox_coi/src/widgets/profile_body.dart';
 import 'package:ox_coi/src/widgets/profile_header.dart';
 import 'package:ox_coi/src/widgets/settings_item.dart';
-import 'package:ox_coi/src/utils/keyMapping.dart';
-
 
 class ChatProfileOneToOne extends StatefulWidget {
   final int chatId;
@@ -134,13 +133,18 @@ class _ChatProfileOneToOneState extends State<ChatProfileOneToOne> {
             child: ProfileHeader(),
           ),
           SettingsItem(
+            pushesNewScreen: true,
             icon: IconSource.flag,
             text: L10n.get(L.settingItemFlaggedTitle),
             key: Key(keyChatProfileSingleIconSourceFlaggedTitle),
             iconBackground: CustomTheme.of(context).flagIcon,
-            onTap: () => _settingsItemTapped(context, SettingsItemName.flagged),
+            onTap: () => _navigation.push(
+              context,
+              MaterialPageRoute(builder: (context) => Flagged(chatId: widget.chatId)),
+            ),
           ),
           SettingsItem(
+            pushesNewScreen: false,
             icon: IconSource.block,
             text: L10n.get(L.contactBlock),
             iconBackground: CustomTheme.of(context).blockIcon,
@@ -160,10 +164,11 @@ class _ChatProfileOneToOneState extends State<ChatProfileOneToOne> {
             ),
           if (!widget.isSelfTalk)
             SettingsItem(
+              pushesNewScreen: true,
               icon: IconSource.notifications,
               text: L10n.get(L.settingItemNotificationsTitle),
               iconBackground: CustomTheme.of(context).notificationIcon,
-              onTap: () => _settingsItemTapped(context, SettingsItemName.notification),
+              onTap: () => _navigation.pushNamed(context, Navigation.settingsNotifications),
             ),
           if (!isInvite())
             ListGroupHeader(
@@ -171,32 +176,16 @@ class _ChatProfileOneToOneState extends State<ChatProfileOneToOne> {
             ),
           if (!isInvite())
             SettingsItem(
+              pushesNewScreen: false,
               icon: IconSource.delete,
               text: L10n.get(L.chatDeleteP),
               textColor: CustomTheme.of(context).error,
               iconBackground: CustomTheme.of(context).blockIcon,
-              showChevron: false,
               onTap: () => showActionDialog(context, ProfileActionType.deleteChat, _deleteChat),
             ),
         ],
       ),
     );
-  }
-
-  _settingsItemTapped(BuildContext context, SettingsItemName settingsItemName) {
-    switch (settingsItemName) {
-      case SettingsItemName.flagged:
-        _navigation.push(
-          context,
-          MaterialPageRoute(builder: (context) => Flagged(chatId: widget.chatId)),
-        );
-        break;
-      case SettingsItemName.notification:
-        _navigation.pushNamed(context, Navigation.settingsNotifications);
-        break;
-      default:
-        break;
-    }
   }
 
   _blockContact() {

--- a/lib/src/contact/contact_change.dart
+++ b/lib/src/contact/contact_change.dart
@@ -178,7 +178,7 @@ class _ContactChangeState extends State<ContactChange> {
               showConfirmationDialog(
                 context: context,
                 title: L10n.get(L.contactGooglemailDialogTitle),
-                content: L10n.get(L.contactGooglemailDialogContent),
+                contentText: L10n.get(L.contactGooglemailDialogContent),
                 positiveButton: L10n.get(L.contactGooglemailDialogPositiveButton),
                 positiveAction: () => _goolemailMailAddressAction(state.name, state.email, true),
                 negativeButton: L10n.get(L.contactGooglemailDialogNegativeButton),
@@ -280,11 +280,7 @@ class _ContactChangeState extends State<ContactChange> {
               ),
             ),
             Padding(
-              padding: const EdgeInsets.only(
-                  top: dimension32dp,
-                  bottom: dimension72dp,
-                  left: formVerticalPadding,
-                  right: formVerticalPadding),
+              padding: const EdgeInsets.only(top: dimension32dp, bottom: dimension72dp, left: formVerticalPadding, right: formVerticalPadding),
               child: Text(
                 L10n.get(L.contactEditPhoneNumberText),
                 style: Theme.of(context).textTheme.caption.apply(color: CustomTheme.of(context).onBackground.half()),
@@ -303,10 +299,14 @@ class _ContactChangeState extends State<ContactChange> {
             Visibility(
               visible: widget.contactAction == ContactAction.add,
               child: SettingsItem(
+                pushesNewScreen: true,
                 icon: IconSource.qr,
                 text: L10n.get(L.qrScan),
                 iconBackground: CustomTheme.of(context).qrIcon,
-                onTap: scanQr,
+                onTap: () => _navigation.push(
+                  context,
+                  MaterialPageRoute(builder: (context) => QrCode(chatId: 0, initialIndex: 1)),
+                ),
               ),
             ),
           ],
@@ -326,15 +326,4 @@ class _ContactChangeState extends State<ContactChange> {
   String _getName() => _nameField.controller.text;
 
   String _getEmail() => widget.contactAction == ContactAction.add ? _emailField.controller.text : widget.email;
-
-  scanQr() {
-    _navigation.push(
-      context,
-      MaterialPageRoute(
-          builder: (context) => QrCode(
-                chatId: 0,
-                initialIndex: 1,
-              )),
-    );
-  }
 }

--- a/lib/src/contact/contact_details.dart
+++ b/lib/src/contact/contact_details.dart
@@ -51,7 +51,6 @@ import 'package:ox_coi/src/contact/contact_item_bloc.dart';
 import 'package:ox_coi/src/contact/contact_item_event_state.dart';
 import 'package:ox_coi/src/data/contact_repository.dart';
 import 'package:ox_coi/src/extensions/string_ui.dart';
-import 'package:ox_coi/src/flagged/flagged.dart';
 import 'package:ox_coi/src/l10n/l.dart';
 import 'package:ox_coi/src/l10n/l10n.dart';
 import 'package:ox_coi/src/navigation/navigatable.dart';
@@ -136,20 +135,15 @@ class _ContactDetailsState extends State<ContactDetails> with ChatCreateMixin {
                     child: ProfileHeader(),
                   ),
                   SettingsItem(
+                    pushesNewScreen: true,
                     key: Key(keyContactDetailOpenChatProfileActionIcon),
                     icon: IconSource.chat,
                     text: L10n.get(L.chatOpen),
                     iconBackground: CustomTheme.of(context).chatIcon,
                     onTap: () => createChatFromContact(context, widget.contactId),
                   ),
-//TODO: This should be discussed (Flagged messages per user)!
-//                  SettingsItem(
-//                    icon: IconSource.flag,
-//                    text: L10n.get(L.settingItemFlaggedTitle),
-//                    iconBackground: CustomTheme.of(context).flagIcon,
-//                    onTap: () => _settingsItemTapped(context, SettingsItemName.flagged),
-//                  ),
                   SettingsItem(
+                    pushesNewScreen: false,
                     key: Key(keyUserProfileBlockIconSource),
                     icon: IconSource.block,
                     text: L10n.get(L.contactBlock),
@@ -168,15 +162,17 @@ class _ContactDetailsState extends State<ContactDetails> with ChatCreateMixin {
                     text: L10n.get(L.settingP),
                   ),
                   SettingsItem(
+                    pushesNewScreen: true,
                     icon: IconSource.notifications,
                     text: L10n.get(L.settingItemNotificationsTitle),
                     iconBackground: CustomTheme.of(context).notificationIcon,
-                    onTap: () => _settingsItemTapped(context, SettingsItemName.notification),
+                    onTap: () => _navigation.pushNamed(context, Navigation.settingsNotifications),
                   ),
                   ListGroupHeader(
                     text: "",
                   ),
                   SettingsItem(
+                    pushesNewScreen: false,
                     key: Key(keyContactDetailDeleteContactProfileActionIcon),
                     icon: IconSource.delete,
                     text: L10n.get(L.contactDelete),
@@ -201,22 +197,6 @@ class _ContactDetailsState extends State<ContactDetails> with ChatCreateMixin {
         ),
       ),
     );
-  }
-
-  _settingsItemTapped(BuildContext context, SettingsItemName settingsItemName) {
-    switch (settingsItemName) {
-      case SettingsItemName.flagged:
-        _navigation.push(
-          context,
-          MaterialPageRoute(builder: (context) => Flagged()),
-        );
-        break;
-      case SettingsItemName.notification:
-        _navigation.pushNamed(context, Navigation.settingsNotifications);
-        break;
-      default:
-        break;
-    }
   }
 
   void _editContact(BuildContext context, String name, String email, String phoneNumbers) async {

--- a/lib/src/contact/contact_item.dart
+++ b/lib/src/contact/contact_item.dart
@@ -137,28 +137,13 @@ class _ContactItemState extends State<ContactItem> with ContactItemBuilder, Chat
   _buildUnblockContactDialog(String name, String email) {
     String contact = name.isNotEmpty ? name : email;
     Navigation navigation = Navigation();
-    return showNavigatableDialog(
+    return showConfirmationDialog(
       context: context,
       navigatable: Navigatable(Type.contactUnblockDialog),
-      dialog: AlertDialog(
-        title: Text(L10n.get(L.contactUnblock)),
-        content: Text(L10n.getFormatted(L.contactUnblockTextX, [contact])),
-        actions: <Widget>[
-          FlatButton(
-            child: Text(L10n.get(L.cancel)),
-            onPressed: () {
-              navigation.pop(context);
-            },
-          ),
-          FlatButton(
-            child: Text(L10n.get(L.unblock)),
-            onPressed: () {
-              unblockContact();
-              navigation.pop(context);
-            },
-          ),
-        ],
-      ),
+      title: L10n.get(L.contactUnblock),
+      contentText: L10n.getFormatted(L.contactUnblockTextX, [contact]),
+      positiveButton: L10n.get(L.unblock),
+      positiveAction: unblockContact,
     );
   }
 

--- a/lib/src/contact/contact_list.dart
+++ b/lib/src/contact/contact_list.dart
@@ -195,7 +195,7 @@ class _ContactListState extends State<ContactList> with ChatCreateMixin {
       showConfirmationDialog(
         context: context,
         title: L10n.get(L.contactGooglemailDialogTitle),
-        content: L10n.get(L.contactGooglemailDialogContent),
+        contentText: L10n.get(L.contactGooglemailDialogContent),
         positiveButton: L10n.get(L.contactGooglemailDialogPositiveButton),
         positiveAction: () => _googleMailMailAddressAction(true),
         negativeButton: L10n.get(L.contactGooglemailDialogNegativeButton),
@@ -278,7 +278,7 @@ class _ContactListState extends State<ContactList> with ChatCreateMixin {
     showConfirmationDialog(
       context: context,
       title: importTitle,
-      content: content,
+      contentText: content,
       positiveButton: importPositive,
       positiveAction: () {
         _progressOverlayEntry = FullscreenOverlay(

--- a/lib/src/l10n/l.dart
+++ b/lib/src/l10n/l.dart
@@ -84,6 +84,7 @@ class L {
   static final import = _translationKey("Import");
   static final inbox = _translationKey("Inbox");
   static final invites = _translationKey("Invites");
+  static final invitation = _translationKey("Invitation");
   static final email = _translationKey("Email");
   static final location = _translationKey("Location");
   static final me = _translationKey("Me");

--- a/lib/src/login/login.dart
+++ b/lib/src/login/login.dart
@@ -100,7 +100,7 @@ class _LoginState extends State<Login> {
         showInformationDialog(
           context: context,
           title: L10n.get(L.loginFailed),
-          content: state.error,
+          contentText: state.error,
           navigatable: Navigatable(Type.loginErrorDialog),
         );
       }

--- a/lib/src/login/login_manual_settings.dart
+++ b/lib/src/login/login_manual_settings.dart
@@ -96,7 +96,7 @@ class _LoginManualSettingsState extends State<LoginManualSettings> {
         showInformationDialog(
           context: context,
           title: L10n.get(L.loginFailed),
-          content: state.error,
+          contentText: state.error,
           navigatable: Navigatable(Type.loginErrorDialog),
         );
       });

--- a/lib/src/login/login_provider_signin.dart
+++ b/lib/src/login/login_provider_signin.dart
@@ -129,7 +129,7 @@ class _ProviderSignInState extends State<ProviderSignIn> {
           showInformationDialog(
             context: context,
             title: L10n.get(L.loginFailed),
-            content: state.error,
+            contentText: state.error,
             navigatable: Navigatable(Type.loginErrorDialog),
           );
         });

--- a/lib/src/main/root.dart
+++ b/lib/src/main/root.dart
@@ -130,70 +130,50 @@ class _RootState extends State<Root> {
                       String chatListInviteDialogXYText = L10n.getFormatted(L.chatListInviteDialogXY, [name, email]);
                       String chatListInviteDialogXText = L10n.getFormatted(L.chatListInviteDialogX, [email]);
                       Uint8List imageBytes = state.base64Image != null ? base64Decode(state.base64Image) : Uint8List(0);
-                      showNavigatableDialog(
+                      showConfirmationDialog(
                         context: context,
                         navigatable: Navigatable(Type.chatListInviteDialog),
-                        dialog: AlertDialog(
-                          content: Row(
-                            children: <Widget>[
-                              Visibility(
-                                visible: imageBytes.length > 0,
+                        title: L10n.get(L.invitation),
+                        content: Row(
+                          children: <Widget>[
+                            Visibility(
+                              visible: imageBytes.length > 0,
+                              child: Padding(
+                                padding: const EdgeInsets.only(right: dimension8dp),
                                 child: Image.memory(
                                   imageBytes,
                                   height: listAvatarDiameter,
                                   width: listAvatarDiameter,
                                 ),
                               ),
-                              Padding(
-                                padding: const EdgeInsets.all(dimension8dp),
-                              ),
-                              Flexible(
-                                child: Text(name == email ? chatListInviteDialogXText : chatListInviteDialogXYText),
-                              )
-                            ],
-                          ),
-                          actions: <Widget>[
-                            FlatButton(
-                              child: Text(L10n.get(L.cancel)),
-                              onPressed: () {
-                                _navigation.pop(context);
-                              },
                             ),
-                            FlatButton(
-                              child: Text(L10n.get(L.chatStart)),
-                              onPressed: () {
-                                _navigation.pop(context);
-                                _inviteBloc.add(AcceptInvite(inviteServiceResponse: inviteServiceResponse));
-                              },
-                            ),
+                            Flexible(
+                              child: Text(name == email ? chatListInviteDialogXText : chatListInviteDialogXYText),
+                            )
                           ],
                         ),
+                        positiveButton: L10n.get(L.chatStart),
+                        positiveAction: () {
+                          _inviteBloc.add(AcceptInvite(inviteServiceResponse: inviteServiceResponse));
+                        },
                       );
                     }
                   } else if (state is InviteStateFailure) {
-                    showNavigatableDialog(
+                    showInformationDialog(
                       context: context,
                       navigatable: Navigatable(Type.chatListInviteErrorDialog),
-                      dialog: AlertDialog(
-                        title: Text(L10n.get(L.error)),
-                        content: Text(state.errorMessage),
-                        actions: <Widget>[
-                          FlatButton(
-                            child: Text(L10n.get(L.ok)),
-                            onPressed: () {
-                              _navigation.pop(context);
-                            },
-                          ),
-                        ],
-                      ),
+                      title: L10n.get(L.error),
+                      contentText: state.errorMessage,
                     );
                   } else if (state is CreateInviteChatSuccess) {
                     _navigation.push(
-                        context,
-                        MaterialPageRoute(
-                            builder: (context) => Chat(
-                                  chatId: state.chatId,
-                                )));
+                      context,
+                      MaterialPageRoute(
+                        builder: (context) => Chat(
+                          chatId: state.chatId,
+                        ),
+                      ),
+                    );
                   }
                 },
               ),

--- a/lib/src/message/message_item.dart
+++ b/lib/src/message/message_item.dart
@@ -310,7 +310,7 @@ class _MessageItemState extends State<MessageItem> with AutomaticKeepAliveClient
     showInformationDialog(
       context: context,
       title: L10n.get(L.error),
-      content: messageInfo,
+      contentText: messageInfo,
       navigatable: Navigatable(Type.messageInfoDialog),
     );
   }

--- a/lib/src/settings/settings_encryption.dart
+++ b/lib/src/settings/settings_encryption.dart
@@ -44,6 +44,8 @@ import 'dart:io';
 
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:ox_coi/src/adaptive_widgets/adaptive_dialog.dart';
+import 'package:ox_coi/src/adaptive_widgets/adaptive_dialog_action.dart';
 import 'package:ox_coi/src/extensions/string_apis.dart';
 import 'package:ox_coi/src/extensions/string_ui.dart';
 import 'package:ox_coi/src/l10n/l.dart';
@@ -106,11 +108,11 @@ class _SettingsEncryptionState extends State<SettingsEncryption> {
           showNavigatableDialog(
             context: context,
             navigatable: Navigatable(Type.settingsKeyTransferDoneDialog),
-            dialog: AlertDialog(
+            dialog: AdaptiveDialog(
               title: Text(L10n.get(L.autocryptMessageCreated)),
               content: new Text(L10n.getFormatted(L.autocryptMessageSentX, [state.setupCode])),
               actions: <Widget>[
-                new FlatButton(
+                AdaptiveDialogAction(
                   child: new Text(L10n.get(L.settingCopyCode)),
                   onPressed: () {
                     var toastText = L10n.getFormatted(L.clipboardCopiedX, [L10n.get(L.code)]);
@@ -118,7 +120,7 @@ class _SettingsEncryptionState extends State<SettingsEncryption> {
                     _navigation.pop(context);
                   },
                 ),
-                new FlatButton(
+                AdaptiveDialogAction(
                   child: new Text(L10n.get(L.ok)),
                   onPressed: () {
                     _navigation.pop(context);
@@ -217,7 +219,7 @@ class _SettingsEncryptionState extends State<SettingsEncryption> {
     showConfirmationDialog(
       context: context,
       title: title,
-      content: text,
+      contentText: text,
       positiveButton: L10n.get(L.ok),
       positiveAction: () => _exportImport(type),
       navigatable: Navigatable(navigationType),
@@ -236,7 +238,7 @@ class _SettingsEncryptionState extends State<SettingsEncryption> {
     showConfirmationDialog(
       context: context,
       title: L10n.get(L.settingKeyTransferStart),
-      content: L10n.get(L.autocryptText),
+      contentText: L10n.get(L.autocryptText),
       positiveButton: L10n.get(L.ok),
       positiveAction: _keyTransfer,
       navigatable: Navigatable(Type.settingsKeyTransferDialog),

--- a/lib/src/user/user_account_settings.dart
+++ b/lib/src/user/user_account_settings.dart
@@ -109,7 +109,7 @@ class _UserAccountSettingsState extends State<UserAccountSettings> {
         showInformationDialog(
           context: context,
           title: L10n.get(L.settingConfigurationChangeFailed),
-          content: state.error,
+          contentText: state.error,
           navigatable: Navigatable(Type.loginErrorDialog),
         );
       }

--- a/lib/src/user/user_profile.dart
+++ b/lib/src/user/user_profile.dart
@@ -165,133 +165,155 @@ class _ProfileState extends State<UserProfile> {
                 child: ProfileHeader(),
               ),
               SettingsItem(
+                pushesNewScreen: true,
                 icon: IconSource.flag,
                 text: L10n.get(L.settingItemFlaggedTitle),
                 iconBackground: CustomTheme.of(context).flagIcon,
-                onTap: () => _settingsItemTapped(context, SettingsItemName.flagged),
+                onTap: () => navigation.push(
+                  context,
+                  MaterialPageRoute(builder: (context) => Flagged()),
+                ),
                 key: Key(keyUserProfileFlagIconSource),
               ),
               SettingsItem(
+                pushesNewScreen: true,
                 icon: IconSource.qr,
                 text: L10n.get(L.settingItemQRTitle),
                 iconBackground: CustomTheme.of(context).qrIcon,
-                onTap: () => _settingsItemTapped(context, SettingsItemName.qrShow),
+                onTap: () => navigation.push(
+                  context,
+                  MaterialPageRoute(builder: (context) => QrCode(chatId: 0)),
+                ),
                 key: Key(keyUserProfileQrIconSource),
               ),
               SettingsItem(
+                pushesNewScreen: false,
                 icon: IconSource.personAdd,
                 text: L10n.get(L.settingItemInviteTitle),
                 iconBackground: CustomTheme.of(context).inviteIcon,
-                onTap: () => _settingsItemTapped(context, SettingsItemName.invite),
+                onTap: _createInviteUrl,
                 key: Key(keyUserProfilePersonAddIconSource),
               ),
               ListGroupHeader(
                 text: L10n.get(L.settingGroupHeaderGeneralTitle),
               ),
               SettingsItem(
+                pushesNewScreen: true,
                 icon: IconSource.appearance,
                 text: SettingsAppearance.viewTitle,
                 iconBackground: CustomTheme.of(context).appearanceIcon,
-                onTap: () => _settingsItemTapped(context, SettingsItemName.appearance),
+                onTap: () => navigation.pushNamed(context, Navigation.settingsAppearance),
                 key: Key(keyUserProfileAppearanceIconSource),
               ),
               SettingsItem(
+                pushesNewScreen: true,
                 icon: IconSource.notifications,
                 text: L10n.get(L.settingItemNotificationsTitle),
                 iconBackground: CustomTheme.of(context).notificationIcon,
-                onTap: () => _settingsItemTapped(context, SettingsItemName.notification),
+                onTap: () => navigation.pushNamed(context, Navigation.settingsNotifications),
                 key: Key(keyUserProfileNotificationIconSource),
               ),
               SettingsItem(
+                pushesNewScreen: true,
                 icon: IconSource.chat,
                 text: L10n.get(L.settingItemChatTitle),
                 iconBackground: CustomTheme.of(context).chatIcon,
-                onTap: () => _settingsItemTapped(context, SettingsItemName.chat),
+                onTap: () => navigation.pushNamed(context, Navigation.settingsChat),
                 key: Key(keyUserProfileChatIconSource),
               ),
               ListGroupHeader(
                 text: L10n.get(L.settingGroupHeaderEmailTitle),
               ),
               SettingsItem(
+                pushesNewScreen: true,
                 icon: IconSource.signature,
                 text: L10n.get(L.settingItemSignatureTitle),
                 iconBackground: CustomTheme.of(context).signatureIcon,
-                onTap: () => _settingsItemTapped(context, SettingsItemName.signature),
+                onTap: () => navigation.push(
+                  context,
+                  MaterialPageRoute(builder: (context) => EmailSignature()),
+                ),
                 key: Key(keyUserProfileSignatureIconSource),
               ),
               SettingsItem(
+                pushesNewScreen: true,
                 icon: IconSource.serverSetting,
                 text: L10n.get(L.settingItemServerSettingsTitle),
                 iconBackground: CustomTheme.of(context).serverSettingsIcon,
-                onTap: () => _settingsItemTapped(context, SettingsItemName.serverSetting),
+                onTap: () => navigation.pushNamed(context, Navigation.settingsAccount),
                 key: Key(keyUserProfileServerSettingIconSource),
               ),
               ListGroupHeader(
                 text: L10n.get(L.settingGroupHeaderSecurityTitle),
               ),
               SettingsItem(
+                pushesNewScreen: true,
                 icon: IconSource.security,
                 text: L10n.get(L.settingItemDataProtectionTitle),
                 iconBackground: CustomTheme.of(context).dataProtectionIcon,
-                onTap: () => _settingsItemTapped(context, SettingsItemName.dataProtection),
+                onTap: () => navigation.pushNamed(context, Navigation.settingsAntiMobbing),
                 key: Key(keyUserProfileSecurityIconSource),
               ),
               SettingsItem(
+                pushesNewScreen: true,
                 icon: IconSource.block,
                 text: L10n.get(L.settingItemBlockedTitle),
                 iconBackground: CustomTheme.of(context).blockIcon,
-                onTap: () => _settingsItemTapped(context, SettingsItemName.blocked),
+                onTap: () => navigation.pushNamed(context, Navigation.contactsBlocked),
                 key: Key(keyUserProfileBlockIconSource),
               ),
               SettingsItem(
+                pushesNewScreen: true,
                 icon: IconSource.lock,
                 text: L10n.get(L.settingItemEncryptionTitle),
                 iconBackground: CustomTheme.of(context).encryptionIcon,
-                onTap: () => _settingsItemTapped(context, SettingsItemName.encryption),
+                onTap: () => navigation.pushNamed(context, Navigation.settingsEncryption),
                 key: Key(keyUserProfileLockIconSource),
               ),
               ListGroupHeader(
                 text: "",
               ),
               SettingsItem(
+                pushesNewScreen: true,
                 icon: IconSource.info,
                 text: L10n.get(L.settingItemAboutTitle),
                 iconBackground: CustomTheme.of(context).aboutIcon,
-                onTap: () => _settingsItemTapped(context, SettingsItemName.about),
+                onTap: () => navigation.pushNamed(context, Navigation.settingsAbout),
                 key: Key(keyUserProfileInfoIconSource),
               ),
               SettingsItem(
+                pushesNewScreen: false,
                 icon: IconSource.feedback,
                 text: L10n.get(L.settingItemFeedbackTitle),
                 iconBackground: CustomTheme.of(context).feedbackIcon,
-                showChevron: false,
-                onTap: () => _settingsItemTapped(context, SettingsItemName.feedback),
+                onTap: () => launch(featureRequestUrl, forceSafariVC: false),
                 key: Key(keyUserProfileFeedbackIconSource),
               ),
               SettingsItem(
+                pushesNewScreen: false,
                 icon: IconSource.bugReport,
                 text: L10n.get(L.settingItemBugReportTitle),
                 iconBackground: CustomTheme.of(context).bugReportIcon,
-                showChevron: false,
-                onTap: () => _settingsItemTapped(context, SettingsItemName.bugReport),
+                onTap: () => launch(issueUrl, forceSafariVC: false),
                 key: Key(keyUserProfileBugReportIconSource),
               ),
               if (!isRelease())
                 SettingsItem(
+                  pushesNewScreen: true,
                   icon: IconSource.bugReport,
                   text: L10n.get(L.debug),
                   iconBackground: CustomTheme.of(context).bugReportIcon,
-                  onTap: () => _settingsItemTapped(context, SettingsItemName.debug),
+                  onTap: () => navigation.pushNamed(context, Navigation.settingsDebug),
                 ),
               ListGroupHeader(
                 text: "",
               ),
               SettingsItem(
+                pushesNewScreen: false,
                 icon: IconSource.logout,
                 text: L10n.get(L.logoutTitle),
                 iconBackground: CustomTheme.of(context).logoutIcon,
-                showChevron: false,
-                onTap: () => _settingsItemTapped(context, SettingsItemName.logout),
+                onTap: () => _showLogoutDialog(context: context),
               ),
             ],
           ),
@@ -300,76 +322,11 @@ class _ProfileState extends State<UserProfile> {
     );
   }
 
-  _settingsItemTapped(BuildContext context, SettingsItemName settingsItemName) {
-    switch (settingsItemName) {
-      case SettingsItemName.flagged:
-        navigation.push(
-          context,
-          MaterialPageRoute(builder: (context) => Flagged()),
-        );
-        break;
-      case SettingsItemName.qrShow:
-        navigation.push(
-          context,
-          MaterialPageRoute(builder: (context) => QrCode(chatId: 0)),
-        );
-        break;
-      case SettingsItemName.invite:
-        _createInviteUrl();
-        break;
-      case SettingsItemName.appearance:
-        navigation.pushNamed(context, Navigation.settingsAppearance);
-        break;
-      case SettingsItemName.notification:
-        navigation.pushNamed(context, Navigation.settingsNotifications);
-        break;
-      case SettingsItemName.chat:
-        navigation.pushNamed(context, Navigation.settingsChat);
-        break;
-      case SettingsItemName.signature:
-        navigation.push(
-          context,
-          MaterialPageRoute(builder: (context) => EmailSignature()),
-        );
-        break;
-      case SettingsItemName.serverSetting:
-        navigation.pushNamed(context, Navigation.settingsAccount);
-        break;
-      case SettingsItemName.darkMode:
-        navigation.pushNamed(context, Navigation.settingsChat);
-        break;
-      case SettingsItemName.dataProtection:
-        navigation.pushNamed(context, Navigation.settingsAntiMobbing);
-        break;
-      case SettingsItemName.blocked:
-        navigation.pushNamed(context, Navigation.contactsBlocked);
-        break;
-      case SettingsItemName.encryption:
-        navigation.pushNamed(context, Navigation.settingsEncryption);
-        break;
-      case SettingsItemName.about:
-        navigation.pushNamed(context, Navigation.settingsAbout);
-        break;
-      case SettingsItemName.feedback:
-        launch(featureRequestUrl, forceSafariVC: false);
-        break;
-      case SettingsItemName.bugReport:
-        launch(issueUrl, forceSafariVC: false);
-        break;
-      case SettingsItemName.logout:
-        _showLogoutDialog(context: context);
-        break;
-      case SettingsItemName.debug:
-        navigation.pushNamed(context, Navigation.settingsDebug);
-        break;
-    }
-  }
-
   void _showLogoutDialog({BuildContext context}) {
     showConfirmationDialog(
       context: context,
       title: L10n.get(L.logoutTitle),
-      content: L10n.get(L.logoutConfirmationText),
+      contentText: L10n.get(L.logoutConfirmationText),
       positiveButton: L10n.get(L.logoutTitle),
       positiveAction: _logoutAction,
       navigatable: Navigatable(Type.logout),

--- a/lib/src/widgets/audio_visualizer.dart
+++ b/lib/src/widgets/audio_visualizer.dart
@@ -101,24 +101,21 @@ class _AudioPlaybackState extends State<AudioPlayback> {
           onHorizontalDragEnd: _replayTime > 0 ? _onHorizontalDragEnd : null,
           onTapDown: _replayTime > 0 ? _onTapUp : null,
           behavior: HitTestBehavior.opaque,
-          child: Container(
-            padding: const EdgeInsets.only(top: voiceRecordingAudioPlaybackTopPadding),
-            child: Stack(
-              children: <Widget>[
-                VoicePainter(
-                  dbPeakList: changeableList,
-                  color: CustomTheme.of(context).onSurface,
-                  withChild: true,
-                  width: _maxWidth,
-                ),
-                VoicePainter(
-                  dbPeakList: changeableList.getRange(0, _replayTime).toList(),
-                  color: CustomTheme.of(context).accent,
-                  withChild: false,
-                  width: _maxWidth,
-                ),
-              ],
-            ),
+          child: Stack(
+            children: <Widget>[
+              VoicePainter(
+                dbPeakList: changeableList,
+                color: CustomTheme.of(context).onSurface,
+                withChild: true,
+                width: _maxWidth,
+              ),
+              VoicePainter(
+                dbPeakList: changeableList.getRange(0, _replayTime).toList(),
+                color: CustomTheme.of(context).accent,
+                withChild: false,
+                width: _maxWidth,
+              ),
+            ],
           ),
         );
       },

--- a/lib/src/widgets/dialog_builder.dart
+++ b/lib/src/widgets/dialog_builder.dart
@@ -50,11 +50,12 @@ import 'package:ox_coi/src/navigation/navigation.dart';
 
 import '../utils/keyMapping.dart';
 
-showNavigatableDialog({@required BuildContext context,
-  @required Widget dialog,
-  @required Navigatable navigatable,
-  Navigatable previousNavigatable,
-  barrierDismissible = true}) {
+showNavigatableDialog(
+    {@required BuildContext context,
+    @required Widget dialog,
+    @required Navigatable navigatable,
+    Navigatable previousNavigatable,
+    barrierDismissible = true}) {
   Navigation navigation = Navigation();
   previousNavigatable = previousNavigatable ?? navigation.current;
   navigation.current = navigatable;
@@ -70,9 +71,11 @@ showNavigatableDialog({@required BuildContext context,
   });
 }
 
-showConfirmationDialog({@required BuildContext context,
+showConfirmationDialog({
+  @required BuildContext context,
   @required String title,
-  @required String content,
+  String contentText,
+  Widget content,
   @required String positiveButton,
   @required Function positiveAction,
   @required Navigatable navigatable,
@@ -81,8 +84,10 @@ showConfirmationDialog({@required BuildContext context,
   Function negativeAction,
   bool selfClose = true,
   barrierDismissible = true,
-  Function onWillPop}) {
+  Function onWillPop,
+}) {
   Navigation navigation = Navigation();
+  assert(content != null || contentText != null);
 
   return showNavigatableDialog(
     context: context,
@@ -93,14 +98,11 @@ showConfirmationDialog({@required BuildContext context,
         onWillPop: onWillPop,
         child: AdaptiveDialog(
           title: Text(title),
-          content: new Text(content),
+          content: content ?? Text(contentText),
           actions: <Widget>[
-            new AdaptiveDialogAction(
+            AdaptiveDialogAction(
               key: Key(keyConfirmationDialogCancelButton),
-              child: new Text(
-                  negativeButton != null && negativeButton.isNotEmpty
-                      ? negativeButton
-                      : L10n.get(L.cancel)),
+              child: Text(negativeButton != null && negativeButton.isNotEmpty ? negativeButton : L10n.get(L.cancel)),
               onPressed: () {
                 if (negativeAction != null) {
                   negativeAction();
@@ -108,9 +110,9 @@ showConfirmationDialog({@required BuildContext context,
                 navigation.pop(context);
               },
             ),
-            new AdaptiveDialogAction(
+            AdaptiveDialogAction(
               key: Key(keyConfirmationDialogPositiveButton),
-              child: new Text(positiveButton),
+              child: Text(positiveButton),
               onPressed: () {
                 positiveAction();
                 if (selfClose) {
@@ -126,7 +128,7 @@ showConfirmationDialog({@required BuildContext context,
 showInformationDialog(
     {@required BuildContext context,
     @required String title,
-    @required String content,
+    @required String contentText,
     @required Navigatable navigatable,
     Navigatable previousNavigatable}) {
   Navigation navigation = Navigation();
@@ -137,11 +139,11 @@ showInformationDialog(
       previousNavigatable: previousNavigatable,
       dialog: AdaptiveDialog(
         title: Text(title),
-        content: new Text(content),
+        content: Text(contentText),
         actions: <Widget>[
-          new AdaptiveDialogAction(
+          AdaptiveDialogAction(
             key: Key(keyInformationDialogPositiveButton),
-            child: new Text(L10n.get(L.ok)),
+            child: Text(L10n.get(L.ok)),
             onPressed: () {
               navigation.pop(context);
             },

--- a/lib/src/widgets/profile_body.dart
+++ b/lib/src/widgets/profile_body.dart
@@ -132,7 +132,7 @@ showActionDialog(BuildContext context, ProfileActionType action, Function onPerf
   return showConfirmationDialog(
     context: context,
     title: title,
-    content: content,
+    contentText: content,
     positiveButton: positiveButton,
     positiveAction: onPerform,
     selfClose: false,

--- a/lib/src/widgets/settings_item.dart
+++ b/lib/src/widgets/settings_item.dart
@@ -49,33 +49,13 @@ import 'package:ox_coi/src/brandable/custom_theme.dart';
 import 'package:ox_coi/src/ui/dimensions.dart';
 import 'package:ox_coi/src/widgets/superellipse_icon.dart';
 
-enum SettingsItemName {
-  flagged,
-  qrShow,
-  invite,
-  appearance,
-  notification,
-  chat,
-  signature,
-  serverSetting,
-  darkMode,
-  dataProtection,
-  blocked,
-  encryption,
-  about,
-  feedback,
-  bugReport,
-  debug,
-  logout,
-}
-
 class SettingsItem extends StatelessWidget {
   final IconSource icon;
   final Color iconBackground;
   final String text;
   final Function onTap;
+  final bool pushesNewScreen;
   final bool showSwitch;
-  final bool showChevron;
   final Function onSwitchChanged;
   final Color textColor;
   final double itemHeight;
@@ -86,8 +66,8 @@ class SettingsItem extends StatelessWidget {
     @required this.iconBackground,
     @required this.text,
     @required this.onTap,
+    @required this.pushesNewScreen,
     this.showSwitch = false,
-    this.showChevron = true,
     this.onSwitchChanged,
     this.textColor,
     this.itemHeight = dimension48dp,
@@ -127,7 +107,7 @@ class SettingsItem extends StatelessWidget {
                 ),
               ),
               Visibility(
-                visible: Platform.isIOS && !showSwitch && showChevron,
+                visible: Platform.isIOS && !showSwitch && pushesNewScreen,
                 child: AdaptiveIcon(
                   icon: IconSource.iosChevron,
                   color: CustomTheme.of(context).onSurface,


### PR DESCRIPTION
**Link to the given issue**
Fixes #534 

**Describe what the problem was / what the new feature is**

- SettingsItem didn't enforce a chevron setting
- Used non-adaptive dialogs
- Unnecessary padding for the audio visualization after recording

**Describe your solution**

- The SettingsItem now enforces a parameter for the chevron. We also discussed about a new widget, but as this is the only difference and making the parameter required is clean and readable, I just made it required and renamed it
- Used adaptive dialogs or even better our pre-build dialogs
- Remove the unneeded padding

**Additional context**
- The confirmation dialog now supports text or child widgets
- Simplified the handling of SettingsItems taps. I just removed the extra mapping, as it wasn't helpful and only lead to unclear code
