### PR TITLE
Message state is not always updated OT-787 #507

### DIFF
--- a/lib/src/chat/chat_event_state.dart
+++ b/lib/src/chat/chat_event_state.dart
@@ -57,35 +57,6 @@ class RequestChat extends ChatEvent {
 
 class ClearNotifications extends ChatEvent {}
 
-class ChatLoaded extends ChatEvent {
-  final String name;
-  final String subTitle;
-  final Color color;
-  final int freshMessageCount;
-  final bool isSelfTalk;
-  final bool isGroupChat;
-  final String preview;
-  final int timestamp;
-  final bool isVerified;
-  final String avatarPath;
-  final bool isRemoved;
-  final String phoneNumbers;
-
-  ChatLoaded(
-      {@required this.name,
-      @required this.subTitle,
-      @required this.color,
-      @required this.freshMessageCount,
-      @required this.isSelfTalk,
-      @required this.isGroupChat,
-      @required this.preview,
-      @required this.timestamp,
-      @required this.isVerified,
-      @required this.avatarPath,
-      @required this.isRemoved,
-      this.phoneNumbers});
-}
-
 abstract class ChatState {}
 
 class ChatStateInitial extends ChatState {}

--- a/lib/src/chatlist/chat_list_item.dart
+++ b/lib/src/chatlist/chat_list_item.dart
@@ -88,13 +88,14 @@ class _ChatListItemState extends State<ChatListItem> {
     return BlocBuilder(
       bloc: _chatBloc,
       builder: (context, state) {
-        String name;
+        String name = "";
         Color color;
         int freshMessageCount = 0;
         int timestamp = 0;
         String preview;
         String imagePath = "";
         bool hasError = false;
+        bool isGroupChat = false;
 
         if (state is ChatStateSuccess) {
           name = state.name;
@@ -103,16 +104,14 @@ class _ChatListItemState extends State<ChatListItem> {
           timestamp = state.timestamp;
           preview = state.preview;
           imagePath = state.avatarPath;
+          isGroupChat = state.isGroupChat;
         } else if (state is ChatStateFailure) {
           hasError = true;
-        } else {
-          name = "";
         }
 
         return Visibility(
           visible: !hasError,
           child: InkWell(
-            //onLongPress: () => chatItemLongPress(),
             child: AvatarListItem(
               title: name,
               subTitle: preview.stripMarkdown(),
@@ -120,7 +119,7 @@ class _ChatListItemState extends State<ChatListItem> {
               imagePath: imagePath,
               freshMessageCount: freshMessageCount,
               timestamp: timestamp,
-              subTitleIcon: _chatBloc.isGroup
+              subTitleIcon: isGroupChat
                   ? AdaptiveIcon(
                       icon: IconSource.group,
                       size: iconSize,

--- a/lib/src/chatlist/invite_item.dart
+++ b/lib/src/chatlist/invite_item.dart
@@ -61,13 +61,13 @@ class InviteItem extends StatefulWidget {
 }
 
 class _InviteItemState extends State<InviteItem> with ChatCreateMixin {
-  MessageItemBloc _messageItemBloc = MessageItemBloc();
+  MessageItemBloc _messageItemBloc = MessageItemBloc(messageListBloc: null);
   Navigation navigation = Navigation();
 
   @override
   void initState() {
     super.initState();
-    _messageItemBloc.add(LoadMessage(chatId: widget.chatId, messageId: widget.messageId, isGroupChat: false));
+    _messageItemBloc.add(LoadMessage(chatId: widget.chatId, messageId: widget.messageId));
   }
 
   @override

--- a/lib/src/contact/contact_item.dart
+++ b/lib/src/contact/contact_item.dart
@@ -136,7 +136,6 @@ class _ContactItemState extends State<ContactItem> with ContactItemBuilder, Chat
 
   _buildUnblockContactDialog(String name, String email) {
     String contact = name.isNotEmpty ? name : email;
-    Navigation navigation = Navigation();
     return showConfirmationDialog(
       context: context,
       navigatable: Navigatable(Type.contactUnblockDialog),

--- a/lib/src/data/repository_stream_handler.dart
+++ b/lib/src/data/repository_stream_handler.dart
@@ -52,17 +52,16 @@ enum Type {
 
 abstract class BaseRepositoryEventStreamHandler {
   final Type type;
-
   final Function onData;
-
-  Function onError;
+  final Function onError;
+  final maxSizeForReplay;
 
   // ignore: close_sinks
   StreamController _streamController; // Closed by flutter-deltachat-core/lib/delta_chat_core.dart
 
-  get streamController => _streamController;
+  StreamController get streamController => _streamController;
 
-  BaseRepositoryEventStreamHandler(this.type, this.onData, [this.onError]) {
+  BaseRepositoryEventStreamHandler(this.type, this.onData, {this.onError, this.maxSizeForReplay}) {
     switch (type) {
       case Type.publish:
         _streamController = PublishSubject();
@@ -71,7 +70,7 @@ abstract class BaseRepositoryEventStreamHandler {
         _streamController = BehaviorSubject();
         break;
       case Type.replay:
-        _streamController = ReplaySubject();
+        _streamController = ReplaySubject(maxSize: maxSizeForReplay);
         break;
     }
   }
@@ -80,12 +79,11 @@ abstract class BaseRepositoryEventStreamHandler {
 class RepositoryEventStreamHandler extends BaseRepositoryEventStreamHandler {
   final int eventId;
 
-  RepositoryEventStreamHandler(Type type, this.eventId, onData, [onError]) : super(type, onData, onError);
-
+  RepositoryEventStreamHandler(Type type, this.eventId, onData, {onError, intMaxSizeForReplay = 10}) : super(type, onData, onError: onError);
 }
 
 class RepositoryMultiEventStreamHandler extends BaseRepositoryEventStreamHandler {
   final List<int> eventIdList;
 
-  RepositoryMultiEventStreamHandler(Type type, this.eventIdList, onData, [onError]) : super(type, onData, onError);
+  RepositoryMultiEventStreamHandler(Type type, this.eventIdList, onData, {onError, intMaxSizeForReplay = 10}) : super(type, onData, onError: onError);
 }

--- a/lib/src/l10n/l.dart
+++ b/lib/src/l10n/l.dart
@@ -443,7 +443,7 @@ class L {
   static final settingsAppearanceSystemTitle = _translationKey("System");
   static final settingsAppearanceDarkTitle = _translationKey("Dark");
   static final settingsAppearanceLightTitle = _translationKey("Light");
-  static final settingsAppearanceDescritpion = _translationKey("Here you can choose your favorite theme. If you choose '%s', the theme may change automatically. This depends on whether you have selected 'Automatic' in the system preferences or not.");
+  static final settingsAppearanceDescription = _translationKey("Here you can choose your favorite theme. If you choose '%s', the theme may change automatically. This depends on whether you have selected 'Automatic' in the system preferences or not.");
   static final settingsAppearanceSystemThemeDescription = _translationKey("Current System theme is: %s");
 
   static List<String> _translationKey(String key, [String pluralKey]) {

--- a/lib/src/message/message_item_event_state.dart
+++ b/lib/src/message/message_item_event_state.dart
@@ -52,12 +52,11 @@ class LoadMessage extends MessageItemEvent {
   final int chatId;
   final int messageId;
   final int nextMessageId;
-  final bool isGroupChat;
 
-  LoadMessage({@required this.chatId, @required this.messageId, this.nextMessageId, @required this.isGroupChat});
+  LoadMessage({@required this.chatId, @required this.messageId, this.nextMessageId});
 
   @override
-  List<Object> get props => [chatId, messageId, nextMessageId, isGroupChat];
+  List<Object> get props => [chatId, messageId, nextMessageId];
 }
 
 class DeleteMessage extends MessageItemEvent {

--- a/lib/src/message/message_list_event_state.dart
+++ b/lib/src/message/message_list_event_state.dart
@@ -70,13 +70,13 @@ class SendMessage extends MessageListEvent {
   SendMessage({this.text, this.path, this.fileType, this.isShared});
 }
 
-class DeleteCacheFile extends MessageListEvent{
+class DeleteCacheFile extends MessageListEvent {
   final String path;
 
   DeleteCacheFile({this.path});
 }
 
-class RetrySendingPendingMessages extends MessageListEvent{}
+class RetrySendingPendingMessages extends MessageListEvent {}
 
 abstract class MessageListState {}
 
@@ -87,9 +87,15 @@ class MessagesStateLoading extends MessageListState {}
 class MessagesStateSuccess extends MessageListState {
   final List<int> messageIds;
   final List<int> messageLastUpdateValues;
+  final Stream messageChangedStream;
   final List<int> dateMarkerIds;
 
-  MessagesStateSuccess({@required this.messageIds, @required this.messageLastUpdateValues, this.dateMarkerIds});
+  MessagesStateSuccess({
+    @required this.messageIds,
+    @required this.messageLastUpdateValues,
+    @required this.messageChangedStream,
+    this.dateMarkerIds,
+  });
 }
 
 class MessagesStateFailure extends MessageListState {

--- a/lib/src/settings/settings_appearance.dart
+++ b/lib/src/settings/settings_appearance.dart
@@ -133,7 +133,7 @@ class _AppearanceSelector extends StatelessWidget {
             Container(
                 padding: EdgeInsets.only(bottom: dimension32dp),
                 child: Text(
-                  L10n.getFormatted(L.settingsAppearanceDescritpion, [L10n.get(L.settingsAppearanceSystemTitle)]),
+                  L10n.getFormatted(L.settingsAppearanceDescription, [L10n.get(L.settingsAppearanceSystemTitle)]),
                 )),
             Row(
               children: <Widget>[


### PR DESCRIPTION
**Link to the given issue**
Fixes #507

**Describe what the problem was / what the new feature is**
The message state was not always updated. Random behavior and missing messages in the chat view / message list view.

**Describe your solution**
The `MessageListBloc` listens now globally to update events for messages and relays + replays those to interested parties. `MessageItemBlocs` aren't listening directly to message state updates anymore. This leads to less core listeners, reliable event handling (late registration within the MessageItemBloc lead to not handled events, resulting in missing states) and a less error prone approach in general. 

**Fixed in this ticket**
- State not updated (sending, sent, read)
- Flickering due to numerous loading cycles or multiple listeners
- Wrong long press menu is shown for failed or attachment messages
- View not updated if a new / freshly sent message fails instantly
- Broken state for messages, which are sent directly after a failed message
- UI error (shortly shown red screen) on deleting a message
- Possibly also fixes #506 (@phranck / @CihanOezkan please have a look)

**Additional context**
- Updated chat_bloc to use less events
- chart.dart buildRow() => ChatAppBar widget
- Moved the MessageList UI into an own widget
- Removed _isGroup variable in ChatBloc (not needed and against best practices)
- Reduce MessagesListBloc count (reusing it via BlocProvider.of instead)
