### PR TITLE
Duplicated notifications #447 OT-715

### DIFF
--- a/lib/src/background_refresh/background_refresh_manager.dart
+++ b/lib/src/background_refresh/background_refresh_manager.dart
@@ -62,7 +62,7 @@ Future<void> getMessages() async {
   await context.interruptIdleForIncomingMessages();
   var localNotificationManager = LocalNotificationManager();
   localNotificationManager.setup();
-  await localNotificationManager.triggerNotification();
+  await localNotificationManager.triggerNotificationAsync();
 }
 
 class BackgroundRefreshManager {

--- a/lib/src/data/repository_manager.dart
+++ b/lib/src/data/repository_manager.dart
@@ -57,7 +57,7 @@ class RepositoryManager {
 
   static Map<String, Repository> _repositories = Map();
 
-  static Repository get(RepositoryType type, [int id]) {
+  static Repository<T> get<T extends Base>(RepositoryType type, [int id]) {
     String identifier = getIdentifier(type, id);
     if (_repositories.containsKey(identifier)) {
       return _repositories[identifier];

--- a/lib/src/l10n/l.dart
+++ b/lib/src/l10n/l.dart
@@ -114,7 +114,7 @@ class L {
   static final readReceiptText = _translationKey(
       "This is a read receipt.\n\nIt means the message was displayed on the recipient's device, not necessarily that the content was read.");
   static final voiceMessage = _translationKey("Voice message");
-  static final moreMessages = _translationKey("more messages");
+  static final moreMessagesX = _translationKey("%d more messages");
   static final privacyDeclaration = _translationKey("privacy declaration");
   static final termsConditions = _translationKey("terms & conditions");
   static final code = _translationKey("Code");

--- a/lib/src/platform/preferences.dart
+++ b/lib/src/platform/preferences.dart
@@ -55,6 +55,8 @@ const preferenceAppState = "preferenceAppState";
 const preferenceInviteServiceUrl = "preferenceInviteServiceUrl";
 const preferenceHasAuthenticationError = "preferenceHasAuthenticationError";
 const preferenceApplicationTheme = "preferenceApplicationTheme";
+const preferenceNotificationHistory = "preferenceNotificationHistory";
+const preferenceNotificationInviteHistory = "preferenceNotificationInviteHistory";
 
 const preferenceNotificationsAuth = "preferenceNotificationsAuth"; // Unused
 const preferenceNotificationsP256dhPublic = "preferenceNotificationsP256dhPublic"; // Unused


### PR DESCRIPTION
**Link to the given issue**
Fixed #447

**Describe what the problem was / what the new feature is**
Notifications were created multiple times for multiple reasons.

**Describe your solution**
We only had a temporary solution to track already shown notifications. Now using the shared preferences / user defaults allows us to persist the notification history. This also simplifies checks if a notification should be shown or not (the general flow is now just `isNewMessageIdOfChatOrInvite > savedMessageId`).

**Additional context**
Added typing via generics to our RepositoryManager (not applied throughout the app, will be done later, as I tried to minimize the code impact of this ticket)
