### PR TITLE
Login screen visible after successful login #562

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -180,7 +180,6 @@ class _OxCoiState extends State<OxCoi> {
         builder: (context, state) {
           if (state is MainStateSuccess) {
             if (state.configured && !state.hasAuthenticationError && state.needsOnboarding) {
-              print("dboehrs DynamicScreen");
               // TODO: NEEDS TO BE DISCUSSED!
               // TODO: Maybe we should add an additional 'Onboarding' layer here, from within the 'DynamicScreen' is being called, just for separation purposes.
               return MultiProvider(providers: [
@@ -189,13 +188,10 @@ class _OxCoiState extends State<OxCoi> {
                 ChangeNotifierProvider<CustomerDelegateChangeNotifier>.value(value: _customerDelegate.changeNotifier)
               ], child: DynamicScreen());
             } else if (state.configured && !state.hasAuthenticationError && !state.needsOnboarding) {
-              print("dboehrs Root");
               return Root();
             } else if (state.configured && state.hasAuthenticationError) {
-              print("dboehrs PasswordChanged");
               return PasswordChanged(passwordChangedCallback: () => _loginSuccess);
             } else {
-              print("dboehrs Login");
               return Login();
             }
           } else {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -185,15 +185,12 @@ class _OxCoiState extends State<OxCoi> {
               ],
               child: DynamicScreen()
             );
-
           } else if (state.configured && !state.hasAuthenticationError && !state.needsOnboarding) {
             child = Root();
-
           } else if (state.configured && state.hasAuthenticationError) {
-            child = PasswordChanged(passwordChangedCallback: () => _loginSuccess(isRelogin: true));
-
+            child = PasswordChanged(passwordChangedCallback: () => _loginSuccess);
           } else {
-            child = Login(success: _loginSuccess);
+            child = Login();
           }
         } else {
           child = Splash();
@@ -203,10 +200,8 @@ class _OxCoiState extends State<OxCoi> {
     );
   }
 
-  void _loginSuccess({bool isRelogin = false}) {
-    if (!isRelogin) {
-      BlocProvider.of<PushBloc>(context).add(RegisterPushResource());
-    }
+  void _loginSuccess() {
+    BlocProvider.of<PushBloc>(context).add(RegisterPushResource());
     _navigation.popUntilRoot(context);
     _mainBloc.add(AppLoaded());
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -49,6 +49,7 @@ import 'package:ox_coi/src/brandable/custom_theme.dart';
 import 'package:ox_coi/src/customer/customer.dart';
 import 'package:ox_coi/src/customer/customer_delegate.dart';
 import 'package:ox_coi/src/customer/customer_delegate_change_notifier.dart';
+import 'package:ox_coi/src/dynamic_screen/dynamic_screen.dart';
 import 'package:ox_coi/src/error/error_bloc.dart';
 import 'package:ox_coi/src/l10n/l10n.dart';
 import 'package:ox_coi/src/lifecycle/lifecycle_bloc.dart';
@@ -61,7 +62,6 @@ import 'package:ox_coi/src/main/main_event_state.dart';
 import 'package:ox_coi/src/main/root.dart';
 import 'package:ox_coi/src/main/splash.dart';
 import 'package:ox_coi/src/navigation/navigation.dart';
-import 'package:ox_coi/src/dynamic_screen/dynamic_screen.dart';
 import 'package:ox_coi/src/push/push_bloc.dart';
 import 'package:ox_coi/src/push/push_event_state.dart';
 import 'package:ox_coi/src/widgets/view_switcher.dart';
@@ -169,34 +169,40 @@ class _OxCoiState extends State<OxCoi> {
 
   @override
   Widget build(BuildContext context) {
-    return BlocBuilder(
-      bloc: _mainBloc,
-      builder: (context, state) {
-        Widget child;
-        if (state is MainStateSuccess) {
-          if (state.configured && !state.hasAuthenticationError && state.needsOnboarding) {
-            // TODO: NEEDS TO BE DISCUSSED!
-            // TODO: Maybe we should add an additional 'Onboarding' layer here, from within the 'DynamicScreen' is being called, just for separation purposes.
-            child = MultiProvider(
-              providers: [
+    return ViewSwitcher(
+      child: BlocConsumer(
+        bloc: _mainBloc,
+        listener: (context, state) {
+          if (state is MainStateSuccess) {
+            _navigation.popUntilRoot(context);
+          }
+        },
+        builder: (context, state) {
+          if (state is MainStateSuccess) {
+            if (state.configured && !state.hasAuthenticationError && state.needsOnboarding) {
+              print("dboehrs DynamicScreen");
+              // TODO: NEEDS TO BE DISCUSSED!
+              // TODO: Maybe we should add an additional 'Onboarding' layer here, from within the 'DynamicScreen' is being called, just for separation purposes.
+              return MultiProvider(providers: [
                 Provider<DynamicScreenModel>.value(value: Customer.onboardingModel),
                 Provider<DynamicScreenCustomerDelegate>.value(value: _customerDelegate),
                 ChangeNotifierProvider<CustomerDelegateChangeNotifier>.value(value: _customerDelegate.changeNotifier)
-              ],
-              child: DynamicScreen()
-            );
-          } else if (state.configured && !state.hasAuthenticationError && !state.needsOnboarding) {
-            child = Root();
-          } else if (state.configured && state.hasAuthenticationError) {
-            child = PasswordChanged(passwordChangedCallback: () => _loginSuccess);
+              ], child: DynamicScreen());
+            } else if (state.configured && !state.hasAuthenticationError && !state.needsOnboarding) {
+              print("dboehrs Root");
+              return Root();
+            } else if (state.configured && state.hasAuthenticationError) {
+              print("dboehrs PasswordChanged");
+              return PasswordChanged(passwordChangedCallback: () => _loginSuccess);
+            } else {
+              print("dboehrs Login");
+              return Login();
+            }
           } else {
-            child = Login();
+            return Splash();
           }
-        } else {
-          child = Splash();
-        }
-        return ViewSwitcher(child);
-      },
+        },
+      ),
     );
   }
 

--- a/lib/src/login/login.dart
+++ b/lib/src/login/login.dart
@@ -70,14 +70,11 @@ class Login extends StatefulWidget {
 class _LoginState extends State<Login> {
   final _navigation = Navigation();
   LoginBloc _loginBloc;
-  // ignore: close_sinks
-  MainBloc _mainBloc;
 
   @override
   void initState() {
     super.initState();
     _navigation.current = Navigatable(Type.login);
-    _mainBloc = BlocProvider.of<MainBloc>(context);
     _loginBloc = LoginBloc(BlocProvider.of<ErrorBloc>(context));
     _loginBloc.add(RequestProviders(type: ProviderListType.login));
   }
@@ -85,105 +82,99 @@ class _LoginState extends State<Login> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      body: BlocListener(
-        bloc: _mainBloc,
-        listener: (context, state) {
-          if (state is MainStateSuccess) {
-            _navigation.popUntilRoot(context);
-          }
-        },
-        child: LayoutBuilder(builder: (BuildContext context, BoxConstraints viewportConstraints) {
-          return SingleChildScrollView(
-            child: ConstrainedBox(
-                constraints: BoxConstraints(
-                  minHeight: viewportConstraints.maxHeight,
-                ),
-                child: IntrinsicHeight(
-                  child: Column(
-                    children: <Widget>[
-                      Container(
-                        color: CustomTheme.of(context).primary,
-                        width: viewportConstraints.maxWidth,
-                        padding: const EdgeInsets.only(top: loginHeaderVerticalPadding, right: loginHorizontalPadding, left: loginHorizontalPadding),
-                        child: Column(
-                          mainAxisAlignment: MainAxisAlignment.end,
-                          children: <Widget>[
-                            Image(
-                              image: AssetImage(appLogoPath),
-                              height: loginLogoSize,
-                              width: loginLogoSize,
+      body: LayoutBuilder(builder: (BuildContext context, BoxConstraints viewportConstraints) {
+        return SingleChildScrollView(
+          child: ConstrainedBox(
+              constraints: BoxConstraints(
+                minHeight: viewportConstraints.maxHeight,
+              ),
+              child: IntrinsicHeight(
+                child: Column(
+                  children: <Widget>[
+                    Container(
+                      color: CustomTheme.of(context).primary,
+                      width: viewportConstraints.maxWidth,
+                      padding: const EdgeInsets.only(top: loginHeaderVerticalPadding, right: loginHorizontalPadding, left: loginHorizontalPadding),
+                      child: Column(
+                        mainAxisAlignment: MainAxisAlignment.end,
+                        children: <Widget>[
+                          Image(
+                            image: AssetImage(appLogoPath),
+                            height: loginLogoSize,
+                            width: loginLogoSize,
+                          ),
+                          Padding(padding: const EdgeInsets.only(top: dimension16dp)),
+                          RichText(
+                            textAlign: TextAlign.center,
+                            text: TextSpan(
+                              style: Theme.of(context).textTheme.caption.apply(color: CustomTheme.of(context).onAccent),
+                              children: getWelcome(),
                             ),
-                            Padding(padding: const EdgeInsets.only(top: dimension16dp)),
-                            RichText(
-                              textAlign: TextAlign.center,
-                              text: TextSpan(
-                                style: Theme.of(context).textTheme.caption.apply(color: CustomTheme.of(context).onAccent),
-                                children: getWelcome(),
-                              ),
-                            ),
-                            Padding(padding: const EdgeInsets.only(top: loginWaveTopBottomPadding)),
-                          ],
-                        ),
+                          ),
+                          Padding(padding: const EdgeInsets.only(top: loginWaveTopBottomPadding)),
+                        ],
                       ),
-                      SizedBox(
+                    ),
+                    RepaintBoundary(
+                      child: SizedBox(
                         width: viewportConstraints.maxWidth,
                         height: loginWaveHeight,
                         child: CustomPaint(
                           painter: CurvePainter(color: CustomTheme.of(context).primary),
                         ),
                       ),
-                      Expanded(
-                        child: Container(
-                          color: CustomTheme.of(context).background,
-                          width: viewportConstraints.maxWidth,
-                          padding: const EdgeInsets.symmetric(horizontal: loginHorizontalPadding),
-                          child: Column(
-                            mainAxisAlignment: MainAxisAlignment.start,
-                            children: <Widget>[
-                              Padding(padding: const EdgeInsets.only(top: loginWaveTopBottomPadding)),
-                              ButtonImportanceHigh(
+                    ),
+                    Expanded(
+                      child: Container(
+                        color: CustomTheme.of(context).background,
+                        width: viewportConstraints.maxWidth,
+                        padding: const EdgeInsets.symmetric(horizontal: loginHorizontalPadding),
+                        child: Column(
+                          mainAxisAlignment: MainAxisAlignment.start,
+                          children: <Widget>[
+                            Padding(padding: const EdgeInsets.only(top: loginWaveTopBottomPadding)),
+                            ButtonImportanceHigh(
+                                minimumWidth: loginButtonWidth,
+                                child: Text(
+                                  L10n.get(L.loginSignIn),
+                                  key: Key(keyLoginLoginSignInText),
+                                ),
+                                onPressed: () {
+                                  _goToProviderList(ProviderListType.login);
+                                }),
+                            Padding(padding: const EdgeInsets.only(top: dimension24dp)),
+                            Padding(
+                              padding: const EdgeInsets.all(dimension8dp),
+                              child: ButtonImportanceLow(
                                   minimumWidth: loginButtonWidth,
                                   child: Text(
-                                    L10n.get(L.loginSignIn),
-                                    key: Key(keyLoginLoginSignInText),
+                                    L10n.get(L.register),
+                                    key: Key(keyLoginRegisterText),
                                   ),
                                   onPressed: () {
-                                    _goToProviderList(ProviderListType.login);
+                                    _goToProviderList(ProviderListType.register);
                                   }),
-                              Padding(padding: const EdgeInsets.only(top: dimension24dp)),
-                              Padding(
-                                padding: const EdgeInsets.all(dimension8dp),
-                                child: ButtonImportanceLow(
-                                    minimumWidth: loginButtonWidth,
-                                    child: Text(
-                                      L10n.get(L.register),
-                                      key: Key(keyLoginRegisterText),
-                                    ),
-                                    onPressed: () {
-                                      _goToProviderList(ProviderListType.register);
-                                    }),
-                              ),
-                              Padding(padding: const EdgeInsets.only(top: dimension64dp)),
-                              Padding(
-                                padding: const EdgeInsets.only(bottom: dimension32dp),
-                                child: RichText(
-                                  textAlign: TextAlign.center,
-                                  text: TextSpan(
-                                    style: Theme.of(context).textTheme.caption.apply(color: CustomTheme.of(context).onBackground),
-                                    children: getAgreeTo(),
-                                  ),
+                            ),
+                            Padding(padding: const EdgeInsets.only(top: dimension64dp)),
+                            Padding(
+                              padding: const EdgeInsets.only(bottom: dimension32dp),
+                              child: RichText(
+                                textAlign: TextAlign.center,
+                                text: TextSpan(
+                                  style: Theme.of(context).textTheme.caption.apply(color: CustomTheme.of(context).onBackground),
+                                  children: getAgreeTo(),
                                 ),
-                              )
-                            ],
-                          ),
+                              ),
+                            )
+                          ],
                         ),
                       ),
-                    ],
-                  ),
-                )),
-          );
-        }),
-      ),
+                    ),
+                  ],
+                ),
+              )),
+        );
+      }),
     );
   }
 

--- a/lib/src/login/login.dart
+++ b/lib/src/login/login.dart
@@ -48,6 +48,8 @@ import 'package:ox_coi/src/l10n/l.dart';
 import 'package:ox_coi/src/l10n/l10n.dart';
 import 'package:ox_coi/src/login/login_bloc.dart';
 import 'package:ox_coi/src/login/login_events_state.dart';
+import 'package:ox_coi/src/main/main_bloc.dart';
+import 'package:ox_coi/src/main/main_event_state.dart';
 import 'package:ox_coi/src/navigation/navigatable.dart';
 import 'package:ox_coi/src/navigation/navigation.dart';
 import 'package:ox_coi/src/ui/dimensions.dart';
@@ -56,154 +58,133 @@ import 'package:ox_coi/src/utils/keyMapping.dart';
 import 'package:ox_coi/src/web/web_asset.dart';
 import 'package:ox_coi/src/widgets/button.dart';
 import 'package:ox_coi/src/widgets/custom_painters.dart';
-import 'package:ox_coi/src/widgets/dialog_builder.dart';
 import 'package:ox_coi/src/widgets/url_text_span.dart';
 
 import 'login_provider_list.dart';
 
 class Login extends StatefulWidget {
-  final Function success;
-
-  Login({@required this.success});
-
   @override
   _LoginState createState() => _LoginState();
 }
 
 class _LoginState extends State<Login> {
+  final _navigation = Navigation();
   LoginBloc _loginBloc;
-  Navigation _navigation = Navigation();
-  bool _showedErrorDialog = false;
-  OverlayEntry _progressOverlayEntry;
+  // ignore: close_sinks
+  MainBloc _mainBloc;
 
   @override
   void initState() {
     super.initState();
     _navigation.current = Navigatable(Type.login);
+    _mainBloc = BlocProvider.of<MainBloc>(context);
     _loginBloc = LoginBloc(BlocProvider.of<ErrorBloc>(context));
     _loginBloc.add(RequestProviders(type: ProviderListType.login));
-    _loginBloc.listen((state) => handleLoginStateChange(state));
-  }
-
-  void handleLoginStateChange(LoginState state) {
-    if (state is LoginStateSuccess || state is LoginStateFailure) {
-      if (_progressOverlayEntry != null) {
-        _progressOverlayEntry.remove();
-        _progressOverlayEntry = null;
-      }
-    }
-    if (state is LoginStateSuccess) {
-      widget.success();
-    } else if (state is LoginStateFailure) {
-      if (!_showedErrorDialog) {
-        _showedErrorDialog = true;
-        showInformationDialog(
-          context: context,
-          title: L10n.get(L.loginFailed),
-          contentText: state.error,
-          navigatable: Navigatable(Type.loginErrorDialog),
-        );
-      }
-    }
   }
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(body: createWelcomeScreen());
-  }
-
-  Widget createWelcomeScreen() {
-    return LayoutBuilder(builder: (BuildContext context, BoxConstraints viewportConstraints) {
-      return SingleChildScrollView(
-        child: ConstrainedBox(
-            constraints: BoxConstraints(
-              minHeight: viewportConstraints.maxHeight,
-            ),
-            child: IntrinsicHeight(
-              child: Column(
-                children: <Widget>[
-                  Container(
-                    color: CustomTheme.of(context).primary,
-                    width: viewportConstraints.maxWidth,
-                    padding: const EdgeInsets.only(top: loginHeaderVerticalPadding, right: loginHorizontalPadding, left: loginHorizontalPadding),
-                    child: Column(
-                      mainAxisAlignment: MainAxisAlignment.end,
-                      children: <Widget>[
-                        Image(
-                          image: AssetImage(appLogoPath),
-                          height: loginLogoSize,
-                          width: loginLogoSize,
-                        ),
-                        Padding(padding: const EdgeInsets.only(top: dimension16dp)),
-                        RichText(
-                          textAlign: TextAlign.center,
-                          text: TextSpan(
-                            style: Theme.of(context).textTheme.caption.apply(color: CustomTheme.of(context).onAccent),
-                            children: getWelcome(),
-                          ),
-                        ),
-                        Padding(padding: const EdgeInsets.only(top: loginWaveTopBottomPadding)),
-                      ],
-                    ),
-                  ),
-                  SizedBox(
-                    width: viewportConstraints.maxWidth,
-                    height: 50,
-                    child: CustomPaint(
-                      painter: CurvePainter(color: CustomTheme.of(context).primary),
-                    ),
-                  ),
-                  Expanded(
-                    child: Container(
-                      color: CustomTheme.of(context).background,
-                      width: viewportConstraints.maxWidth,
-                      padding: const EdgeInsets.symmetric(horizontal: loginHorizontalPadding),
-                      child: Column(
-                        mainAxisAlignment: MainAxisAlignment.start,
-                        children: <Widget>[
-                          Padding(padding: const EdgeInsets.only(top: loginWaveTopBottomPadding)),
-                          ButtonImportanceHigh(
-                              minimumWidth: loginButtonWidth,
-                              child: Text(
-                                L10n.get(L.loginSignIn),
-                                key: Key(keyLoginLoginSignInText),
-                              ),
-                              onPressed: () {
-                                _goToProviderList(ProviderListType.login);
-                              }),
-                          Padding(padding: const EdgeInsets.only(top: dimension24dp)),
-                          Padding(
-                            padding: const EdgeInsets.all(dimension8dp),
-                            child: ButtonImportanceLow(
-                                minimumWidth: loginButtonWidth,
-                                child: Text(
-                                  L10n.get(L.register),
-                                  key: Key(keyLoginRegisterText),
-                                ),
-                                onPressed: () {
-                                  _goToProviderList(ProviderListType.register);
-                                }),
-                          ),
-                          Padding(padding: const EdgeInsets.only(top: dimension64dp)),
-                          Padding(
-                            padding: const EdgeInsets.only(bottom: dimension32dp),
-                            child: RichText(
+    return Scaffold(
+      body: BlocListener(
+        bloc: _mainBloc,
+        listener: (context, state) {
+          if (state is MainStateSuccess) {
+            _navigation.popUntilRoot(context);
+          }
+        },
+        child: LayoutBuilder(builder: (BuildContext context, BoxConstraints viewportConstraints) {
+          return SingleChildScrollView(
+            child: ConstrainedBox(
+                constraints: BoxConstraints(
+                  minHeight: viewportConstraints.maxHeight,
+                ),
+                child: IntrinsicHeight(
+                  child: Column(
+                    children: <Widget>[
+                      Container(
+                        color: CustomTheme.of(context).primary,
+                        width: viewportConstraints.maxWidth,
+                        padding: const EdgeInsets.only(top: loginHeaderVerticalPadding, right: loginHorizontalPadding, left: loginHorizontalPadding),
+                        child: Column(
+                          mainAxisAlignment: MainAxisAlignment.end,
+                          children: <Widget>[
+                            Image(
+                              image: AssetImage(appLogoPath),
+                              height: loginLogoSize,
+                              width: loginLogoSize,
+                            ),
+                            Padding(padding: const EdgeInsets.only(top: dimension16dp)),
+                            RichText(
                               textAlign: TextAlign.center,
                               text: TextSpan(
-                                style: Theme.of(context).textTheme.caption.apply(color: CustomTheme.of(context).onBackground),
-                                children: getAgreeTo(),
+                                style: Theme.of(context).textTheme.caption.apply(color: CustomTheme.of(context).onAccent),
+                                children: getWelcome(),
                               ),
                             ),
-                          )
-                        ],
+                            Padding(padding: const EdgeInsets.only(top: loginWaveTopBottomPadding)),
+                          ],
+                        ),
                       ),
-                    ),
+                      SizedBox(
+                        width: viewportConstraints.maxWidth,
+                        height: loginWaveHeight,
+                        child: CustomPaint(
+                          painter: CurvePainter(color: CustomTheme.of(context).primary),
+                        ),
+                      ),
+                      Expanded(
+                        child: Container(
+                          color: CustomTheme.of(context).background,
+                          width: viewportConstraints.maxWidth,
+                          padding: const EdgeInsets.symmetric(horizontal: loginHorizontalPadding),
+                          child: Column(
+                            mainAxisAlignment: MainAxisAlignment.start,
+                            children: <Widget>[
+                              Padding(padding: const EdgeInsets.only(top: loginWaveTopBottomPadding)),
+                              ButtonImportanceHigh(
+                                  minimumWidth: loginButtonWidth,
+                                  child: Text(
+                                    L10n.get(L.loginSignIn),
+                                    key: Key(keyLoginLoginSignInText),
+                                  ),
+                                  onPressed: () {
+                                    _goToProviderList(ProviderListType.login);
+                                  }),
+                              Padding(padding: const EdgeInsets.only(top: dimension24dp)),
+                              Padding(
+                                padding: const EdgeInsets.all(dimension8dp),
+                                child: ButtonImportanceLow(
+                                    minimumWidth: loginButtonWidth,
+                                    child: Text(
+                                      L10n.get(L.register),
+                                      key: Key(keyLoginRegisterText),
+                                    ),
+                                    onPressed: () {
+                                      _goToProviderList(ProviderListType.register);
+                                    }),
+                              ),
+                              Padding(padding: const EdgeInsets.only(top: dimension64dp)),
+                              Padding(
+                                padding: const EdgeInsets.only(bottom: dimension32dp),
+                                child: RichText(
+                                  textAlign: TextAlign.center,
+                                  text: TextSpan(
+                                    style: Theme.of(context).textTheme.caption.apply(color: CustomTheme.of(context).onBackground),
+                                    children: getAgreeTo(),
+                                  ),
+                                ),
+                              )
+                            ],
+                          ),
+                        ),
+                      ),
+                    ],
                   ),
-                ],
-              ),
-            )),
-      );
-    });
+                )),
+          );
+        }),
+      ),
+    );
   }
 
   void _goToProviderList(ProviderListType type) {
@@ -212,7 +193,6 @@ class _LoginState extends State<Login> {
       MaterialPageRoute(
         builder: (context) => ProviderList(
           type: type,
-          success: widget.success,
         ),
       ),
     );
@@ -220,10 +200,10 @@ class _LoginState extends State<Login> {
 
   List<TextSpan> getWelcome() {
     int spanBoundary = 0;
-    var oxCoiName = L10n.get(L.oxCoiName);
-    var formattedWelcomeString = L10n.getFormatted(L.welcome, [oxCoiName]);
-    var oxCoiNameStartIndex = formattedWelcomeString.indexOf(oxCoiName, spanBoundary);
-    var oxCoiNameEndIndex = oxCoiNameStartIndex + oxCoiName.length;
+    final oxCoiName = L10n.get(L.oxCoiName);
+    final formattedWelcomeString = L10n.getFormatted(L.welcome, [oxCoiName]);
+    final oxCoiNameStartIndex = formattedWelcomeString.indexOf(oxCoiName, spanBoundary);
+    final oxCoiNameEndIndex = oxCoiNameStartIndex + oxCoiName.length;
 
     List<TextSpan> textParts = [];
     textParts.add(TextSpan(
@@ -245,13 +225,13 @@ class _LoginState extends State<Login> {
 
   List<TextSpan> getAgreeTo() {
     int spanBoundary = 0;
-    var termsAndConditions = L10n.get(L.termsConditions);
-    var privacyPolicy = L10n.get(L.privacyDeclaration);
-    var formattedAgreeString = L10n.getFormatted(L.agreeToXY, [termsAndConditions, privacyPolicy]);
-    var termsConditionsStartIndex = formattedAgreeString.indexOf(termsAndConditions, spanBoundary);
-    var termsConditionsEndIndex = termsConditionsStartIndex + termsAndConditions.length;
-    var privacyPolicyStartIndex = formattedAgreeString.indexOf(privacyPolicy, spanBoundary);
-    var privacyPolicyEndIndex = privacyPolicyStartIndex + privacyPolicy.length;
+    final termsAndConditions = L10n.get(L.termsConditions);
+    final privacyPolicy = L10n.get(L.privacyDeclaration);
+    final formattedAgreeString = L10n.getFormatted(L.agreeToXY, [termsAndConditions, privacyPolicy]);
+    final termsConditionsStartIndex = formattedAgreeString.indexOf(termsAndConditions, spanBoundary);
+    final termsConditionsEndIndex = termsConditionsStartIndex + termsAndConditions.length;
+    final privacyPolicyStartIndex = formattedAgreeString.indexOf(privacyPolicy, spanBoundary);
+    final privacyPolicyEndIndex = privacyPolicyStartIndex + privacyPolicy.length;
 
     List<TextSpan> textParts = [];
     textParts.add(TextSpan(text: formattedAgreeString.substring(spanBoundary, termsConditionsStartIndex)));

--- a/lib/src/login/login_events_state.dart
+++ b/lib/src/login/login_events_state.dart
@@ -132,7 +132,9 @@ class LoginStateLoading extends LoginState {
   LoginStateLoading({@required progress}) : super(progress: progress);
 }
 
-class LoginStateSuccess extends LoginState {}
+class LoginStateSuccess extends LoginState {
+  final progress = 1000;
+}
 
 class LoginStateProvidersLoaded extends LoginState {
   List<Provider> providers;

--- a/lib/src/main/root.dart
+++ b/lib/src/main/root.dart
@@ -178,7 +178,7 @@ class _RootState extends State<Root> {
                 },
               ),
             ],
-            child: ViewSwitcher(child),
+            child: ViewSwitcher(child: child),
           ),
         ),
         bottomNavigationBar: BottomNavigationBar(

--- a/lib/src/ui/animations.dart
+++ b/lib/src/ui/animations.dart
@@ -1,0 +1,1 @@
+const kProgressDismissDelay = 250;

--- a/lib/src/ui/dimensions.dart
+++ b/lib/src/ui/dimensions.dart
@@ -162,6 +162,7 @@ const loginProviderIconSizeBig = 150.0;
 const loginErrorOverlayLeftPadding = dimension12dp;
 const loginOtherProviderButtonRadius = 22.0;
 const loginWaveTopBottomPadding = dimension32dp;
+const loginWaveHeight = 50.0;
 
 // Voice Recording
 const voiceRecordingAudioPlaybackTopPadding = 30.0;

--- a/lib/src/widgets/fullscreen_progress.dart
+++ b/lib/src/widgets/fullscreen_progress.dart
@@ -50,6 +50,7 @@ import 'package:ox_coi/src/brandable/custom_theme.dart';
 import 'package:ox_coi/src/l10n/l.dart';
 import 'package:ox_coi/src/l10n/l10n.dart';
 import 'package:ox_coi/src/navigation/navigation.dart';
+import 'package:ox_coi/src/ui/animations.dart';
 import 'package:ox_coi/src/ui/dimensions.dart';
 import 'package:ox_coi/src/widgets/button.dart';
 
@@ -65,7 +66,7 @@ class FullscreenOverlay<T extends Bloc> extends OverlayEntry {
     Navigation().allowBackNavigation = true;
     if (_isVisible) {
       _isVisible = false;
-      super.remove();
+      Future.delayed(Duration(milliseconds: kProgressDismissDelay), () => super.remove());
     }
   }
 }
@@ -94,6 +95,7 @@ class FullscreenProgress<T extends Bloc> extends StatelessWidget {
         if (state is ProgressState && state.progress != null) {
           progress = state.progress;
         }
+        print("dboehrs $state with $progress");
         return GestureDetector(
           behavior: HitTestBehavior.opaque,
           child: BackdropFilter(

--- a/lib/src/widgets/fullscreen_progress.dart
+++ b/lib/src/widgets/fullscreen_progress.dart
@@ -95,7 +95,6 @@ class FullscreenProgress<T extends Bloc> extends StatelessWidget {
         if (state is ProgressState && state.progress != null) {
           progress = state.progress;
         }
-        print("dboehrs $state with $progress");
         return GestureDetector(
           behavior: HitTestBehavior.opaque,
           child: BackdropFilter(

--- a/lib/src/widgets/view_switcher.dart
+++ b/lib/src/widgets/view_switcher.dart
@@ -45,7 +45,7 @@ import 'package:flutter/material.dart';
 class ViewSwitcher extends AnimatedSwitcher {
   static const defaultDuration = Duration(milliseconds: 200);
 
-  ViewSwitcher(Widget child)
+  ViewSwitcher({@required Widget child})
       : super(
             duration: defaultDuration,
             transitionBuilder: (Widget child, Animation<double> animation) => FadeTransition(child: child, opacity: animation),


### PR DESCRIPTION
**Link to the given issue**
https://github.com/open-xchange/ox-coi/issues/562

**Describe what the problem was / what the new feature is**
After a successful login the screen jumps to the first login page and then to the next one (onboarding). The correct way is to go directly to the next page.

**Describe your solution**
The `login.dart` listens to the `MainStateSuccess` and after this the navigation stack is cleared.

**Additional context**
- Cleaned up the login pages
- Removed unused listeners
- Removed methods that return a Widget