### PR TITLE
Remove Notifications Setting from Chat Profile #572

### DIFF
--- a/lib/src/chat/chat_profile_group.dart
+++ b/lib/src/chat/chat_profile_group.dart
@@ -123,16 +123,6 @@ class _ChatProfileGroupState extends State<ChatProfileGroup> {
                         onTap: () => _navigation.push(context, MaterialPageRoute(builder: (context) => Flagged(chatId: widget.chatId))),
                       ),
                       ListGroupHeader(
-                        text: L10n.get(L.settingP),
-                      ),
-                      SettingsItem(
-                        pushesNewScreen: true,
-                        icon: IconSource.notifications,
-                        text: L10n.get(L.settingItemNotificationsTitle),
-                        iconBackground: CustomTheme.of(context).notificationIcon,
-                        onTap: () => _navigation.pushNamed(context, Navigation.settingsNotifications),
-                      ),
-                      ListGroupHeader(
                         text: L10n.getFormatted(L.participantXP, [state.contactIds.length], count: state.contactIds.length),
                       ),
                       Visibility(

--- a/lib/src/chat/chat_profile_single.dart
+++ b/lib/src/chat/chat_profile_single.dart
@@ -158,18 +158,6 @@ class _ChatProfileOneToOneState extends State<ChatProfileOneToOne> {
               },
             ),
           ),
-          if (!widget.isSelfTalk)
-            ListGroupHeader(
-              text: L10n.get(L.settingP),
-            ),
-          if (!widget.isSelfTalk)
-            SettingsItem(
-              pushesNewScreen: true,
-              icon: IconSource.notifications,
-              text: L10n.get(L.settingItemNotificationsTitle),
-              iconBackground: CustomTheme.of(context).notificationIcon,
-              onTap: () => _navigation.pushNamed(context, Navigation.settingsNotifications),
-            ),
           if (!isInvite())
             ListGroupHeader(
               text: "",

--- a/lib/src/customer/customer.dart
+++ b/lib/src/customer/customer.dart
@@ -73,7 +73,9 @@ class Customer {
 
   Future<void> configureOnboardingAsync() async {
     try {
-      await _loadCoiSettings();
+      _isCoiEnabled = (await Context().isCoiSupported()) == 1;
+      _isCoiSupported = (await Context().isCoiSupported()) == 1;
+
       Map<String, dynamic> jsonFile = await rootBundle.loadString(customerOnboardingConfigPath).then((jsonStr) => jsonDecode(jsonStr));
       _onboardingModel = DynamicScreenModel.fromJson(jsonFile);
 
@@ -87,7 +89,6 @@ class Customer {
 
   Future<void> _configureCustomerAsync() async {
     try {
-      await _loadCoiSettings();
       Map<String, dynamic> jsonFile = await rootBundle.loadString(customerConfigPath).then((jsonStr) => jsonDecode(jsonStr));
       _config = CustomerConfig.fromJson(jsonFile);
       _needsOnboarding = await getPreference(preferenceNeedsOnboarding) as bool ?? true;
@@ -96,11 +97,6 @@ class Customer {
       _logger.shout("[Configure Customer] ** ERROR **: ${error.toString()}");
       throw(error.toString());
     }
-  }
-
-  Future<void> _loadCoiSettings()async{
-    _isCoiEnabled = (await Context().isCoiSupported()) == 1;
-    _isCoiSupported = (await Context().isCoiSupported()) == 1;
   }
 
   // Customer Config

--- a/lib/src/customer/customer.dart
+++ b/lib/src/customer/customer.dart
@@ -73,9 +73,7 @@ class Customer {
 
   Future<void> configureOnboardingAsync() async {
     try {
-      _isCoiEnabled = (await Context().isCoiSupported()) == 1;
-      _isCoiSupported = (await Context().isCoiSupported()) == 1;
-
+      await _loadCoiSettings();
       Map<String, dynamic> jsonFile = await rootBundle.loadString(customerOnboardingConfigPath).then((jsonStr) => jsonDecode(jsonStr));
       _onboardingModel = DynamicScreenModel.fromJson(jsonFile);
 
@@ -89,6 +87,7 @@ class Customer {
 
   Future<void> _configureCustomerAsync() async {
     try {
+      await _loadCoiSettings();
       Map<String, dynamic> jsonFile = await rootBundle.loadString(customerConfigPath).then((jsonStr) => jsonDecode(jsonStr));
       _config = CustomerConfig.fromJson(jsonFile);
       _needsOnboarding = await getPreference(preferenceNeedsOnboarding) as bool ?? true;
@@ -97,6 +96,11 @@ class Customer {
       _logger.shout("[Configure Customer] ** ERROR **: ${error.toString()}");
       throw(error.toString());
     }
+  }
+
+  Future<void> _loadCoiSettings()async{
+    _isCoiEnabled = (await Context().isCoiSupported()) == 1;
+    _isCoiSupported = (await Context().isCoiSupported()) == 1;
   }
 
   // Customer Config


### PR DESCRIPTION
**Link to the given issue**
Fixes https://github.com/open-xchange/ox-coi/issues/572

**Describe what the problem was / what the new feature is**
The notification settings button in the chat profiles is misleading and should be removed.

**Describe your solution**
Removed the button from the chat profiles.

**Additional context**
Fixed that the `settings_notifications.dart` is always empty. Reason: COI settings
```
_isCoiEnabled = (await Context().isCoiSupported()) == 1;
_isCoiSupported = (await Context().isCoiSupported()) == 1;
```
were not loaded after normal start.