### PR TITLE
Fix chat and profile not updating #565 OT-828 OT-832

### DIFF
--- a/lib/src/chat/chat_event_state.dart
+++ b/lib/src/chat/chat_event_state.dart
@@ -55,6 +55,8 @@ class RequestChat extends ChatEvent {
   RequestChat({@required this.chatId, this.isHeadless = false, this.messageId});
 }
 
+class UpdateChat extends ChatEvent {}
+
 class ClearNotifications extends ChatEvent {}
 
 abstract class ChatState {}

--- a/lib/src/contact/contact_change_bloc.dart
+++ b/lib/src/contact/contact_change_bloc.dart
@@ -109,16 +109,18 @@ class ContactChangeBloc extends Bloc<ContactChangeEvent, ContactChangeState> wit
     if (address.contains(googlemailDomain)) {
       yield GoogleContactDetected(name: name, email: address);
     } else {
-      int id = await context.createContact(name, address);
       if (contactAction == ContactAction.add) {
-        add(ContactAdded(id: id));
+        int contactId = await context.createContact(name, address);
+        add(ContactAdded(id: contactId));
       } else {
-        Contact contact = contactRepository.get(id);
-        contact.set(Contact.methodContactGetName, name);
-        int chatId = await context.getChatByContactId(id);
+        int contactId = await context.getContactIdByAddress(address);
+        int chatId = await context.getChatByContactId(contactId);
         if (chatId != 0) {
           _renameChat(chatId, name);
         }
+        await context.createContact(name, address);
+        Contact contact = contactRepository.get(contactId);
+        contact.set(Contact.methodContactGetName, name);
         add(ContactEdited());
       }
     }


### PR DESCRIPTION
**Link to the given issue**
Fixes #565 and [internal bug tracker 1](https://jira.open-xchange.com/browse/OT-828) + [internal bug tracker 2](https://jira.open-xchange.com/browse/OT-832)

**Describe what the problem was / what the new feature is**
- Group name was not updated in the profile view and the chat title after editing the group chat via the chat profile view
- Chat name was not updated after editing the contact via the chat profile view

The general problem was the change to generator methods (`yield*` / `async*`), which in general is good, but we used it wrong. A `yield*` call must stay in the `mapEventToState` method, so other callers must issue events to trigger the method, where then the correct handling is applied.

**Describe your solution**
- Now adding the `UpdateChat`event and refreshing the chat, if a relevant event comes in
- Now listening also to contact changes (not only chat changes), to also fix 1 to 1 chat update problems
- Fixed chat name update handling lib/src/contact/contact_change_bloc.dart

**Additional context**
- Clean up UI and reusing of provided BloCs, instead of creating new ones over and over again (lib/src/chat/chat_profile.dart and lib/src/chat/chat_profile_group.dart)