### PR TITLE
Message test unreliable #554

### DIFF
--- a/test_driver/setup/helper_methods.dart
+++ b/test_driver/setup/helper_methods.dart
@@ -159,6 +159,7 @@ Future unflagMessage(FlutterDriver driver,String flagUnFlag, int messageIdToUnFl
 }
 
 Future flaggedMessage(FlutterDriver driver, String flagUnFlag, SerializableFinder messageToFlaggedFinder) async {
+  sleep(Duration(seconds: 5));
   await performLongPress(driver, messageToFlaggedFinder);
   await driver.tap(find.text(flagUnFlag));
 }


### PR DESCRIPTION
**Link to the given issue**
#554 

**Describe what the problem was / what the new feature is**
Sometimes the message test is unreliable. It fails during long press actions on mails.

**Describe your solution**
Timeout added in flaggedMessage() function.

