### PR TITLE
Profile picture can't be deleted #589 OT-843

### DIFF
--- a/lib/src/adaptive_widgets/adaptive_bottom_sheet.dart
+++ b/lib/src/adaptive_widgets/adaptive_bottom_sheet.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:ox_coi/src/l10n/l.dart';
+import 'package:ox_coi/src/l10n/l10n.dart';
+import 'package:ox_coi/src/navigation/navigation.dart';
+import 'package:ox_coi/src/utils/keyMapping.dart';
+
+import 'adaptive_widget.dart';
+
+class AdaptiveBottomSheet extends AdaptiveWidget<CupertinoActionSheet, Column> {
+  final List<Widget> actions;
+
+  AdaptiveBottomSheet({
+    Key key,
+    @required this.actions,
+  }) : super(childKey: key);
+
+  @override
+  CupertinoActionSheet buildCupertinoWidget(BuildContext context) {
+    return CupertinoActionSheet(
+      key: childKey,
+      actions: actions,
+      cancelButton: CupertinoActionSheetAction(
+        key: Key(keyAdaptiveBottomSheetCancel),
+        child: Text(L10n.get(L.cancel)),
+        isDefaultAction: true,
+        onPressed: () => Navigation().pop(context),
+      ),
+    );
+  }
+
+  @override
+  Column buildMaterialWidget(BuildContext context) {
+    return Column(
+      key: childKey,
+      mainAxisSize: MainAxisSize.min,
+      children: actions,
+    );
+  }
+}

--- a/lib/src/adaptive_widgets/adaptive_bottom_sheet_action.dart
+++ b/lib/src/adaptive_widgets/adaptive_bottom_sheet_action.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+import 'adaptive_widget.dart';
+
+class AdaptiveBottomSheetAction extends AdaptiveWidget<CupertinoActionSheetAction, ListTile> {
+  final Widget title;
+  final Widget leading;
+  final bool isDestructive;
+  final Function onPressed;
+
+  AdaptiveBottomSheetAction({
+    @required Key key,
+    @required this.title,
+    @required this.onPressed,
+    this.leading,
+    this.isDestructive = false,
+  }) : super(childKey: key);
+
+  @override
+  ListTile buildMaterialWidget(BuildContext context) {
+    return ListTile(
+      key: childKey,
+      leading: leading,
+      title: title,
+      onTap: onPressed,
+    );
+  }
+
+  @override
+  CupertinoActionSheetAction buildCupertinoWidget(BuildContext context) {
+    return CupertinoActionSheetAction(
+      key: childKey,
+      child: title,
+      isDestructiveAction: isDestructive,
+      onPressed: onPressed,
+    );
+  }
+}

--- a/lib/src/adaptive_widgets/adaptive_dialog.dart
+++ b/lib/src/adaptive_widgets/adaptive_dialog.dart
@@ -10,9 +10,9 @@ class AdaptiveDialog extends AdaptiveWidget<CupertinoAlertDialog, AlertDialog> {
 
   AdaptiveDialog({
     Key key,
-    this.title,
-    this.content,
-    this.actions,
+    @required this.title,
+    @required this.content,
+    @required this.actions,
   }) : super(childKey: key);
 
   @override

--- a/lib/src/adaptive_widgets/adaptive_dialog_action.dart
+++ b/lib/src/adaptive_widgets/adaptive_dialog_action.dart
@@ -8,9 +8,9 @@ class AdaptiveDialogAction extends AdaptiveWidget<CupertinoDialogAction, FlatBut
   final Function onPressed;
 
   AdaptiveDialogAction({
-    Key key,
-    this.child,
-    this.onPressed,
+    @required Key key,
+    @required this.child,
+    @required this.onPressed,
   }) : super(childKey: key);
 
   @override

--- a/lib/src/chat/chat.dart
+++ b/lib/src/chat/chat.dart
@@ -47,6 +47,7 @@ import 'package:file_picker/file_picker.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:ox_coi/src/adaptive_widgets/adaptive_bottom_sheet_action.dart';
 import 'package:ox_coi/src/brandable/brandable_icon.dart';
 import 'package:ox_coi/src/brandable/custom_theme.dart';
 import 'package:ox_coi/src/chat/chat_bloc.dart';
@@ -80,7 +81,7 @@ import 'package:ox_coi/src/utils/keyMapping.dart';
 import 'package:ox_coi/src/utils/vibration.dart';
 import 'package:ox_coi/src/widgets/avatar.dart';
 import 'package:ox_coi/src/widgets/button.dart';
-import 'package:ox_coi/src/widgets/dialog_builder.dart';
+import 'package:ox_coi/src/widgets/modal_builder.dart';
 import 'package:ox_coi/src/widgets/dynamic_appbar.dart';
 import 'package:ox_coi/src/widgets/superellipse_icon.dart';
 import 'package:path/path.dart' as Path;
@@ -657,35 +658,38 @@ class _ChatState extends State<Chat> with ChatComposer, ChatCreateMixin, InviteM
   }
 
   void _showAttachmentChooser() {
-    showModalBottomSheet(
+    showNavigatableBottomSheet(
         context: context,
-        builder: (BuildContext context) {
-          return Column(
-            mainAxisSize: MainAxisSize.min,
-            children: <Widget>[
-              ListTile(
-                leading: AdaptiveIcon(icon: IconSource.image),
-                title: Text(L10n.get(L.image)),
-                onTap: () => _getFilePath(FileType.image),
-              ),
-              ListTile(
-                leading: AdaptiveIcon(icon: IconSource.videoLibrary),
-                title: Text(L10n.get(L.video)),
-                onTap: () => _getFilePath(FileType.video),
-              ),
-              ListTile(
-                leading: AdaptiveIcon(icon: IconSource.pictureAsPdf),
-                title: Text(pdf),
-                onTap: () => _getFilePath(FileType.custom, "pdf"),
-              ),
-              ListTile(
-                leading: AdaptiveIcon(icon: IconSource.insertDriveFile),
-                title: Text(L10n.get(L.file)),
-                onTap: () => _getFilePath(FileType.any),
-              ),
-            ],
-          );
-        });
+        navigatable: Navigatable(Type.addAttachmentModal),
+        bottomSheet: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            AdaptiveBottomSheetAction(
+              key: Key(keyAttachmentAddImage),
+              title: Text(L10n.get(L.image)),
+              leading: AdaptiveIcon(icon: IconSource.image),
+              onPressed: () => _getFilePath(FileType.image),
+            ),
+            AdaptiveBottomSheetAction(
+              key: Key(keyAttachmentAddVideo),
+              title: Text(L10n.get(L.video)),
+              leading: AdaptiveIcon(icon: IconSource.videoLibrary),
+              onPressed: () => _getFilePath(FileType.video),
+            ),
+            AdaptiveBottomSheetAction(
+              key: Key(keyAttachmentAddPdf),
+              title: Text(pdf),
+              leading: AdaptiveIcon(icon: IconSource.pictureAsPdf),
+              onPressed: () => _getFilePath(FileType.custom, "pdf"),
+            ),
+            AdaptiveBottomSheetAction(
+              key: Key(keyAttachmentAddFile),
+              title: Text(L10n.get(L.file)),
+              leading: AdaptiveIcon(icon: IconSource.insertDriveFile),
+              onPressed: () => _getFilePath(FileType.any),
+            ),
+          ],
+        ));
   }
 
   _getFilePath(FileType fileType, [String extension]) async {

--- a/lib/src/contact/contact_change.dart
+++ b/lib/src/contact/contact_change.dart
@@ -61,7 +61,7 @@ import 'package:ox_coi/src/navigation/navigation.dart';
 import 'package:ox_coi/src/qr/qr.dart';
 import 'package:ox_coi/src/ui/dimensions.dart';
 import 'package:ox_coi/src/utils/keyMapping.dart';
-import 'package:ox_coi/src/widgets/dialog_builder.dart';
+import 'package:ox_coi/src/widgets/modal_builder.dart';
 import 'package:ox_coi/src/widgets/dynamic_appbar.dart';
 import 'package:ox_coi/src/widgets/list_group_header.dart';
 import 'package:ox_coi/src/widgets/settings_item.dart';

--- a/lib/src/contact/contact_item.dart
+++ b/lib/src/contact/contact_item.dart
@@ -53,7 +53,7 @@ import 'package:ox_coi/src/l10n/l.dart';
 import 'package:ox_coi/src/l10n/l10n.dart';
 import 'package:ox_coi/src/navigation/navigatable.dart';
 import 'package:ox_coi/src/navigation/navigation.dart';
-import 'package:ox_coi/src/widgets/dialog_builder.dart';
+import 'package:ox_coi/src/widgets/modal_builder.dart';
 
 import 'contact_details.dart';
 

--- a/lib/src/contact/contact_list.dart
+++ b/lib/src/contact/contact_list.dart
@@ -65,7 +65,7 @@ import 'package:ox_coi/src/navigation/navigation.dart';
 import 'package:ox_coi/src/ui/dimensions.dart';
 import 'package:ox_coi/src/utils/keyMapping.dart';
 import 'package:ox_coi/src/utils/key_generator.dart';
-import 'package:ox_coi/src/widgets/dialog_builder.dart';
+import 'package:ox_coi/src/widgets/modal_builder.dart';
 import 'package:ox_coi/src/widgets/dynamic_appbar.dart';
 import 'package:ox_coi/src/widgets/fullscreen_progress.dart';
 import 'package:ox_coi/src/widgets/state_info.dart';

--- a/lib/src/customer/customer_delegate.dart
+++ b/lib/src/customer/customer_delegate.dart
@@ -47,6 +47,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:image_cropper/image_cropper.dart';
 import 'package:image_picker/image_picker.dart';
+import 'package:ox_coi/src/adaptive_widgets/adaptive_bottom_sheet.dart';
+import 'package:ox_coi/src/adaptive_widgets/adaptive_bottom_sheet_action.dart';
 import 'package:ox_coi/src/brandable/brandable_icon.dart';
 import 'package:ox_coi/src/customer/customer.dart';
 import 'package:ox_coi/src/customer/customer_delegate_change_notifier.dart';
@@ -58,10 +60,13 @@ import 'package:ox_coi/src/l10n/l.dart';
 import 'package:ox_coi/src/l10n/l10n.dart';
 import 'package:ox_coi/src/main/main_bloc.dart';
 import 'package:ox_coi/src/main/main_event_state.dart';
+import 'package:ox_coi/src/navigation/navigatable.dart';
 import 'package:ox_coi/src/navigation/navigation.dart';
 import 'package:ox_coi/src/platform/preferences.dart';
 import 'package:ox_coi/src/platform/system_interaction.dart';
 import 'package:ox_coi/src/ui/dimensions.dart';
+import 'package:ox_coi/src/utils/keyMapping.dart';
+import 'package:ox_coi/src/widgets/modal_builder.dart';
 import 'package:permission_handler/permission_handler.dart';
 import 'package:provider/provider.dart';
 
@@ -134,27 +139,27 @@ class CustomerDelegate with DynamicScreenCustomerDelegate {
   void avatarPressedCallback({BuildContext context, data}) {
     debugPrint("[Avatar] => Data: $data");
     unFocus(context);
-    showModalBottomSheet(
-        context: context,
-        builder: (BuildContext sheetContext) {
-          return SafeArea(
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: <Widget>[
-                ListTile(
-                  leading: AdaptiveIcon(icon: IconSource.photo),
-                  title: Text(L10n.get(L.gallery)),
-                  onTap: () => _getNewAvatarPathAsync(sheetContext, ImageSource.gallery),
-                ),
-                ListTile(
-                  leading: AdaptiveIcon(icon: IconSource.cameraAlt),
-                  title: Text(L10n.get(L.camera)),
-                  onTap: () => _getNewAvatarPathAsync(sheetContext, ImageSource.camera),
-                ),
-              ],
-            ),
-          );
-        });
+
+    showNavigatableBottomSheet(
+      context: context,
+      navigatable: Navigatable(Type.changeProfilePhotoModal),
+      bottomSheet: AdaptiveBottomSheet(
+        actions: <Widget>[
+          AdaptiveBottomSheetAction(
+            key: Key(keyAdaptiveBottomSheetGallery),
+            title: Text(L10n.get(L.gallery)),
+            leading: AdaptiveIcon(icon: IconSource.photo),
+            onPressed: () => _getNewAvatarPathAsync(context, ImageSource.gallery),
+          ),
+          AdaptiveBottomSheetAction(
+            key: Key(keyAdaptiveBottomSheetCamera),
+            title: Text(L10n.get(L.camera)),
+            leading: AdaptiveIcon(icon: IconSource.cameraAlt),
+            onPressed: () => _getNewAvatarPathAsync(context, ImageSource.camera),
+          ),
+        ],
+      ),
+    );
   }
 
   @override

--- a/lib/src/login/login_manual_settings.dart
+++ b/lib/src/login/login_manual_settings.dart
@@ -55,7 +55,7 @@ import 'package:ox_coi/src/settings/settings_manual_form.dart';
 import 'package:ox_coi/src/settings/settings_manual_form_bloc.dart';
 import 'package:ox_coi/src/settings/settings_manual_form_event_state.dart';
 import 'package:ox_coi/src/ui/dimensions.dart';
-import 'package:ox_coi/src/widgets/dialog_builder.dart';
+import 'package:ox_coi/src/widgets/modal_builder.dart';
 import 'package:ox_coi/src/widgets/dynamic_appbar.dart';
 import 'package:ox_coi/src/widgets/fullscreen_progress.dart';
 

--- a/lib/src/login/login_provider_signin.dart
+++ b/lib/src/login/login_provider_signin.dart
@@ -54,7 +54,7 @@ import 'package:ox_coi/src/navigation/navigation.dart';
 import 'package:ox_coi/src/ui/dimensions.dart';
 import 'package:ox_coi/src/utils/keyMapping.dart';
 import 'package:ox_coi/src/widgets/button.dart';
-import 'package:ox_coi/src/widgets/dialog_builder.dart';
+import 'package:ox_coi/src/widgets/modal_builder.dart';
 import 'package:ox_coi/src/widgets/dynamic_appbar.dart';
 import 'package:ox_coi/src/widgets/error_banner.dart';
 import 'package:ox_coi/src/widgets/fullscreen_progress.dart';

--- a/lib/src/main/root.dart
+++ b/lib/src/main/root.dart
@@ -65,7 +65,7 @@ import 'package:ox_coi/src/navigation/navigation.dart';
 import 'package:ox_coi/src/ui/dimensions.dart';
 import 'package:ox_coi/src/user/user_profile.dart';
 import 'package:ox_coi/src/utils/text_field_handling.dart';
-import 'package:ox_coi/src/widgets/dialog_builder.dart';
+import 'package:ox_coi/src/widgets/modal_builder.dart';
 import 'package:ox_coi/src/widgets/view_switcher.dart';
 import 'package:provider/provider.dart';
 

--- a/lib/src/message/message_item.dart
+++ b/lib/src/message/message_item.dart
@@ -62,7 +62,7 @@ import 'package:ox_coi/src/settings/settings_autocrypt_import.dart';
 import 'package:ox_coi/src/share/share.dart';
 import 'package:ox_coi/src/ui/dimensions.dart';
 import 'package:ox_coi/src/utils/text_field_handling.dart';
-import 'package:ox_coi/src/widgets/dialog_builder.dart';
+import 'package:ox_coi/src/widgets/modal_builder.dart';
 
 import '../message_list/message_list_bloc.dart';
 import 'message_action.dart';

--- a/lib/src/navigation/navigatable.dart
+++ b/lib/src/navigation/navigatable.dart
@@ -44,7 +44,9 @@ import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 
 enum Type {
+  addAttachmentModal,
   antiMobbingList,
+  changeProfilePhotoModal,
   chat,
   chatAddGroupParticipants,
   chatCreate,

--- a/lib/src/settings/settings_encryption.dart
+++ b/lib/src/settings/settings_encryption.dart
@@ -56,7 +56,8 @@ import 'package:ox_coi/src/platform/files.dart';
 import 'package:ox_coi/src/settings/settings_encryption_bloc.dart';
 import 'package:ox_coi/src/settings/settings_encryption_event_state.dart';
 import 'package:ox_coi/src/ui/dimensions.dart';
-import 'package:ox_coi/src/widgets/dialog_builder.dart';
+import 'package:ox_coi/src/utils/keyMapping.dart';
+import 'package:ox_coi/src/widgets/modal_builder.dart';
 import 'package:ox_coi/src/widgets/dynamic_appbar.dart';
 import 'package:ox_coi/src/widgets/fullscreen_progress.dart';
 
@@ -113,6 +114,7 @@ class _SettingsEncryptionState extends State<SettingsEncryption> {
               content: new Text(L10n.getFormatted(L.autocryptMessageSentX, [state.setupCode])),
               actions: <Widget>[
                 AdaptiveDialogAction(
+                  key: Key(keySettingsEncryptionDialogCodeCopy),
                   child: new Text(L10n.get(L.settingCopyCode)),
                   onPressed: () {
                     var toastText = L10n.getFormatted(L.clipboardCopiedX, [L10n.get(L.code)]);
@@ -121,6 +123,7 @@ class _SettingsEncryptionState extends State<SettingsEncryption> {
                   },
                 ),
                 AdaptiveDialogAction(
+                  key: Key(keySettingsEncryptionDialogCodeOk),
                   child: new Text(L10n.get(L.ok)),
                   onPressed: () {
                     _navigation.pop(context);

--- a/lib/src/user/user_account_settings.dart
+++ b/lib/src/user/user_account_settings.dart
@@ -58,7 +58,7 @@ import 'package:ox_coi/src/settings/settings_manual_form_bloc.dart';
 import 'package:ox_coi/src/settings/settings_manual_form_event_state.dart';
 import 'package:ox_coi/src/ui/dimensions.dart';
 import 'package:ox_coi/src/utils/keyMapping.dart';
-import 'package:ox_coi/src/widgets/dialog_builder.dart';
+import 'package:ox_coi/src/widgets/modal_builder.dart';
 import 'package:ox_coi/src/widgets/dynamic_appbar.dart';
 import 'package:ox_coi/src/widgets/fullscreen_progress.dart';
 

--- a/lib/src/user/user_profile.dart
+++ b/lib/src/user/user_profile.dart
@@ -68,7 +68,7 @@ import 'package:ox_coi/src/user/user_event_state.dart';
 import 'package:ox_coi/src/user/user_settings.dart';
 import 'package:ox_coi/src/utils/constants.dart';
 import 'package:ox_coi/src/utils/keyMapping.dart';
-import 'package:ox_coi/src/widgets/dialog_builder.dart';
+import 'package:ox_coi/src/widgets/modal_builder.dart';
 import 'package:ox_coi/src/widgets/dynamic_appbar.dart';
 import 'package:ox_coi/src/widgets/fullscreen_progress.dart';
 import 'package:ox_coi/src/widgets/list_group_header.dart';

--- a/lib/src/utils/keyMapping.dart
+++ b/lib/src/utils/keyMapping.dart
@@ -136,3 +136,16 @@ const keyLoginRegisterText = "keyLoginRegisterText";
 const keyDynamicNavigationNext = "keyDynamicNavigationNext";
 const keyDynamicNavigationBack = "keyDynamicNavigationBack";
 const keyDynamicNavigationSkip = "appbarSkipButton"; // Used in the dynamic onboarding to skip the whole process
+
+const keyAdaptiveBottomSheetCancel = "keyAdaptiveBottomSheetCancel";
+const keyAdaptiveBottomSheetGallery = "keyAdaptiveBottomSheetPhoto";
+const keyAdaptiveBottomSheetCamera = "keyAdaptiveBottomSheetCamera";
+const keyAdaptiveBottomSheetRemove = "keyAdaptiveBottomSheetRemove";
+
+const keySettingsEncryptionDialogCodeCopy = "keySettingsEncryptionCopyCode";
+const keySettingsEncryptionDialogCodeOk = "keySettingsEncryptionCodeOk";
+
+const keyAttachmentAddImage = "keyAttachmentAddImage";
+const keyAttachmentAddVideo = "keyAttachmentAddVideo";
+const keyAttachmentAddPdf = "keyAttachmentAddPdf";
+const keyAttachmentAddFile = "keyAttachmentAddFile";

--- a/lib/src/widgets/modal_builder.dart
+++ b/lib/src/widgets/modal_builder.dart
@@ -40,6 +40,9 @@
  * for more details.
  */
 
+import 'dart:io';
+
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:ox_coi/src/adaptive_widgets/adaptive_dialog.dart';
 import 'package:ox_coi/src/adaptive_widgets/adaptive_dialog_action.dart';
@@ -49,6 +52,36 @@ import 'package:ox_coi/src/navigation/navigatable.dart';
 import 'package:ox_coi/src/navigation/navigation.dart';
 
 import '../utils/keyMapping.dart';
+
+showNavigatableBottomSheet({
+  @required BuildContext context,
+  @required Widget bottomSheet,
+  @required Navigatable navigatable,
+  Navigatable previousNavigatable,
+}) {
+  Navigation navigation = Navigation();
+  previousNavigatable = previousNavigatable ?? navigation.current;
+  navigation.current = navigatable;
+  if (Platform.isIOS) {
+    return showCupertinoModalPopup(
+      context: context,
+      builder: (BuildContext context) {
+        return bottomSheet;
+      },
+    ).then((value) {
+      navigation.current = previousNavigatable;
+    });
+  } else {
+    return showModalBottomSheet(
+      context: context,
+      builder: (BuildContext context) {
+        return bottomSheet;
+      },
+    ).then((value) {
+      navigation.current = previousNavigatable;
+    });
+  }
+}
 
 showNavigatableDialog(
     {@required BuildContext context,

--- a/lib/src/widgets/profile_body.dart
+++ b/lib/src/widgets/profile_body.dart
@@ -46,7 +46,7 @@ import 'package:ox_coi/src/extensions/string_apis.dart';
 import 'package:ox_coi/src/l10n/l.dart';
 import 'package:ox_coi/src/l10n/l10n.dart';
 import 'package:ox_coi/src/navigation/navigatable.dart';
-import 'package:ox_coi/src/widgets/dialog_builder.dart';
+import 'package:ox_coi/src/widgets/modal_builder.dart';
 
 
 class ProfileActionList extends StatelessWidget {

--- a/lib/src/widgets/profile_header.dart
+++ b/lib/src/widgets/profile_header.dart
@@ -45,6 +45,8 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:image_cropper/image_cropper.dart';
 import 'package:image_picker/image_picker.dart';
+import 'package:ox_coi/src/adaptive_widgets/adaptive_bottom_sheet.dart';
+import 'package:ox_coi/src/adaptive_widgets/adaptive_bottom_sheet_action.dart';
 import 'package:ox_coi/src/brandable/brandable_icon.dart';
 import 'package:ox_coi/src/brandable/custom_theme.dart';
 import 'package:ox_coi/src/extensions/color_apis.dart';
@@ -52,13 +54,17 @@ import 'package:ox_coi/src/extensions/string_apis.dart';
 import 'package:ox_coi/src/extensions/string_ui.dart';
 import 'package:ox_coi/src/l10n/l.dart';
 import 'package:ox_coi/src/l10n/l10n.dart';
+import 'package:ox_coi/src/navigation/navigatable.dart';
 import 'package:ox_coi/src/navigation/navigation.dart';
 import 'package:ox_coi/src/ui/dimensions.dart';
 import 'package:ox_coi/src/ui/text_styles.dart';
 import 'package:ox_coi/src/utils/keyMapping.dart';
 import 'package:ox_coi/src/widgets/avatar.dart';
+import 'package:ox_coi/src/widgets/modal_builder.dart';
 import 'package:ox_coi/src/widgets/placeholder_text.dart';
 import 'package:ox_coi/src/widgets/superellipse_icon.dart';
+
+import 'modal_builder.dart';
 
 class ProfileData extends InheritedWidget {
   final Color imageBackgroundColor;
@@ -189,33 +195,34 @@ class ProfileAvatar extends StatelessWidget {
     }
 
     _editPhoto() {
-      showModalBottomSheet(
-          context: context,
-          builder: (BuildContext context) {
-            return Column(
-              mainAxisSize: MainAxisSize.min,
-              children: <Widget>[
-                ListTile(
-                  leading: AdaptiveIcon(icon: IconSource.photo),
-                  title: Text(L10n.get(L.gallery)),
-                  onTap: () => _getNewAvatarPath(ImageSource.gallery),
-                ),
-                ListTile(
-                  leading: AdaptiveIcon(icon: IconSource.cameraAlt),
-                  title: Text(L10n.get(L.camera)),
-                  onTap: () => _getNewAvatarPath(ImageSource.camera),
-                ),
-                Visibility(
-                  visible: _isImageAvailable,
-                  child: ListTile(
-                    leading: AdaptiveIcon(icon: IconSource.delete),
-                    title: Text(L10n.get(L.groupRemoveImage)),
-                    onTap: () => _removeAvatar(),
-                  ),
-                )
-              ],
-            );
-          });
+      showNavigatableBottomSheet(
+        context: context,
+        navigatable: Navigatable(Type.changeProfilePhotoModal),
+        bottomSheet: AdaptiveBottomSheet(
+          actions: <Widget>[
+            AdaptiveBottomSheetAction(
+              key: Key(keyAdaptiveBottomSheetGallery),
+              title: Text(L10n.get(L.gallery)),
+              leading: AdaptiveIcon(icon: IconSource.photo),
+              onPressed: () => _getNewAvatarPath(ImageSource.gallery),
+            ),
+            AdaptiveBottomSheetAction(
+              key: Key(keyAdaptiveBottomSheetCamera),
+              title: Text(L10n.get(L.camera)),
+              leading: AdaptiveIcon(icon: IconSource.cameraAlt),
+              onPressed: () => _getNewAvatarPath(ImageSource.camera),
+            ),
+            if (_isImageAvailable)
+              AdaptiveBottomSheetAction(
+                key: Key(keyAdaptiveBottomSheetRemove),
+                title: Text(L10n.get(L.groupRemoveImage)),
+                leading: AdaptiveIcon(icon: IconSource.delete),
+                isDestructive: true,
+                onPressed: _removeAvatar,
+              ),
+          ],
+        ),
+      );
     }
 
     return InkWell(
@@ -391,10 +398,11 @@ class EditableProfileHeader extends StatelessWidget {
               child: Column(
                 children: <Widget>[
                   TextFormField(
-                      key: Key(keyUserSettingsUsernameLabel),
-                      maxLines: 1,
-                      controller: nameController,
-                      decoration: InputDecoration(labelText: placeholder)),
+                    key: Key(keyUserSettingsUsernameLabel),
+                    maxLines: 1,
+                    controller: nameController,
+                    decoration: InputDecoration(labelText: placeholder),
+                  ),
                 ],
               ),
             ),


### PR DESCRIPTION
**Link to the given issue**
Fixed #589 

**Describe what the problem was / what the new feature is**
We used the bottom sheet on Android and iOS, but on iOS the native action sheet should be used.

**Describe your solution**
- Created a new adaptive widget using the bottom sheet on Android and the action sheet on iOS.
- Applied the new widget (Onboarding, profile, add attachment)

**Additional context**
- Small renaming
- On Android everything should just look the same and behave the same
- On iOS the UI for modal bottom popups should be more native now
