### PR TITLE
Onboarding deletes profile name if screen is changed #588 OT-842

### DIFF
--- a/lib/src/dynamic_screen/widgets/page_components/page_textfield_component.dart
+++ b/lib/src/dynamic_screen/widgets/page_components/page_textfield_component.dart
@@ -50,9 +50,6 @@ import 'package:provider/provider.dart';
 class PageTextFieldComponent extends PageBaseComponent {
   final DynamicScreenTextfieldModel model;
 
-  final _textController = TextEditingController();
-  final _focusNode = FocusNode();
-
   PageTextFieldComponent({Key key, this.model}) : super(key: key);
 
   @override
@@ -67,13 +64,12 @@ class PageTextFieldComponent extends PageBaseComponent {
       builder: (context, changeNotifier, child) {
         return Padding(
           padding: model.padding.edgeInsetsValue,
-          child: TextField(
+          child: TextFormField(
+            initialValue: changeNotifier.userName,
             keyboardType: TextInputType.text,
             textCapitalization: TextCapitalization.none,
             textInputAction: TextInputAction.done,
             decoration: decoration,
-            controller: _textController,
-            focusNode: _focusNode,
             key: Key(L.getKey(L.type)),
             onChanged: (value) {
               customerDelegate.textfieldEditingCompleteAsync(context: context, value: value);


### PR DESCRIPTION
**Link to the given issue**
Fixes #588 

**Describe what the problem was / what the new feature is**

- Username deleted when selecting avatar after setting the name
- Username deleted when choosing next and afterwards going back

**Describe your solution**

Added the initial value to the widget.

**Additional context**

- Removed unneeded components.
