### PR TITLE
HOTFIX: Tap contact on create chat view is not working

### DIFF
--- a/lib/src/chat/chat_create.dart
+++ b/lib/src/chat/chat_create.dart
@@ -47,6 +47,7 @@ import 'package:ox_coi/src/brandable/brandable_icon.dart';
 import 'package:ox_coi/src/brandable/custom_theme.dart';
 import 'package:ox_coi/src/chat/chat_create_group_participants.dart';
 import 'package:ox_coi/src/contact/contact_change.dart';
+import 'package:ox_coi/src/contact/contact_item.dart';
 import 'package:ox_coi/src/contact/contact_list_bloc.dart';
 import 'package:ox_coi/src/contact/contact_list_content.dart';
 import 'package:ox_coi/src/contact/contact_list_event_state.dart';
@@ -131,7 +132,7 @@ class _ChatCreateState extends State<ChatCreate> {
               final adjustedIndex = index - offset;
               final contactElement = state.contactElements[adjustedIndex];
 
-              return ContactListContent(contactElement: contactElement, hasHeader: true);
+              return ContactListContent(contactElement: contactElement, hasHeader: true, contactItemType: ContactItemType.createChat,);
             }
           }, childCount: state.contactElements.length + offset),
         )


### PR DESCRIPTION
**Describe what the problem was / what the new feature is**
It was not possible to create a chat over the "ChatCreate.dart" view.

**Describe your solution**
Added the missing `contactItemType: ContactItemType.createChat` to the `ContactListContent` widget.
